### PR TITLE
remove -static compile flag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,6 @@ extra_compile_args = [
     '-O3',
     '-fpic',
     '-g',
-    '-static',
 ]
 extra_link_args = None
 


### PR DESCRIPTION
I think we had this there while trying to get the build to work, but I don't think it should be necessary. Tests pass locally and on Travis without it.
