### PR TITLE
Don't use tr1/memory on recent Mac OS X versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import os
+import platform
 import sys
 
 from ez_setup import use_setuptools
@@ -58,8 +59,6 @@ source_files = [
 ]
 
 extra_compile_args = [
-    '-DMACOSX',
-    '-DLINUX',
     '-w',
     '-std=c++0x',
     '-O3',
@@ -77,6 +76,11 @@ elif os.environ.get('USEOPENMP') or not sys.platform.startswith('darwin'):
     extra_link_args = [
         '-lgomp'
     ]
+
+if platform.system() == 'Darwin':
+    mac_ver = [int(x) for x in platform.mac_ver()[0].split('.')]
+    if mac_ver >= [10, 9]:
+        extra_compile_args += ['-D NO_TR1_MEMORY']
 
 version = '0.2dev'
 

--- a/src/contraction_hierarchies/src/POIIndex/POIIndex.h
+++ b/src/contraction_hierarchies/src/POIIndex/POIIndex.h
@@ -22,12 +22,12 @@
 
 #include <vector>
 
-#ifdef _WIN32
+#if defined _WIN32 || defined NO_TR1_MEMORY
 #include <memory>
 #else
 #include <tr1/memory>
-#endif
 #define shared_ptr tr1::shared_ptr
+#endif
 
 #include "../BasicDefinitions.h"
 #include "../DataStructures/BinaryHeap.h"


### PR DESCRIPTION
The newer SDKs for Mac OS X don't have the `<tr1/memory>`
headers, you can use just `<memory>`.
This adds a check of the system Mac version in setup.py and
if it is 10.9 or later add's the flag `-D NO_TR1_MEMORY` to the
compiler arguments. Then that's used in an `#if` in `POIIndex.h`
to use `<memory>` instead of `<tr1/memory>`.

Seems to work on my Mac running 10.10, but I wasn't running into this issue
anyway because conda's Python targets the Mac 10.5 SDK.
