### PR TITLE
Reindex

### DIFF
--- a/pandana/tests/test_utils.py
+++ b/pandana/tests/test_utils.py
@@ -18,7 +18,7 @@ def dataframe():
 @pytest.fixture
 def series():
     data = {'value': [10, 20, 30, 40, 50]}
-    index = [11,22,33,44,55]
+    index = [11, 22, 33, 44, 55]
     df = pd.DataFrame(data, index)
     df.index.name = 'id'
     s = pd.Series(df.value, df.index)

--- a/pandana/tests/test_utils.py
+++ b/pandana/tests/test_utils.py
@@ -1,0 +1,34 @@
+import pandas as pd
+import pytest
+
+from pandana.utils import reindex
+
+
+@pytest.fixture
+def dataframe():
+    data = {'node_id': [44, 55, 33, 22, 11],
+            'x': [-122, -123, -124, -125, -126],
+            'y': [37, 38, 39, 40, 41]}
+    index = [1, 2, 3, 4, 5]
+
+    df = pd.DataFrame(data, index)
+    return df
+
+
+@pytest.fixture
+def series():
+    data = {'value': [10, 20, 30, 40, 50]}
+    index = [11,22,33,44,55]
+    df = pd.DataFrame(data, index)
+    df.index.name = 'id'
+    s = pd.Series(df.value, df.index)
+    return s
+
+
+def test_reindex(dataframe, series):
+
+    results = pd.DataFrame({'value': reindex(series, dataframe.node_id)})
+
+    assert len(results) == 5
+    assert results['value'][1] == 40
+    assert results['value'][5] == 10

--- a/pandana/tests/test_utils.py
+++ b/pandana/tests/test_utils.py
@@ -5,7 +5,7 @@ from pandana.utils import reindex
 
 
 @pytest.fixture
-def dataframe():
+def node_df():
     data = {'node_id': [44, 55, 33, 22, 11],
             'x': [-122, -123, -124, -125, -126],
             'y': [37, 38, 39, 40, 41]}
@@ -16,7 +16,7 @@ def dataframe():
 
 
 @pytest.fixture
-def series():
+def result_series():
     data = {'value': [10, 20, 30, 40, 50]}
     index = [11, 22, 33, 44, 55]
     df = pd.DataFrame(data, index)
@@ -25,10 +25,11 @@ def series():
     return s
 
 
-def test_reindex(dataframe, series):
+def test_reindex(node_df, result_series):
 
-    results = pd.DataFrame({'value': reindex(series, dataframe.node_id)})
+    reindexed_results = pd.DataFrame({'value': reindex(result_series,
+                                                       node_df.node_id)})
 
-    assert len(results) == 5
-    assert results['value'][1] == 40
-    assert results['value'][5] == 10
+    assert len(reindexed_results) == 5
+    assert reindexed_results['value'][1] == 40
+    assert reindexed_results['value'][5] == 10

--- a/pandana/utils.py
+++ b/pandana/utils.py
@@ -1,0 +1,21 @@
+import pandas as pd
+
+
+def reindex(series1, series2):
+    """
+    Reindex the first series by the second series.
+
+    Parameters
+    ----------
+    series1 : pd.Series
+        Pandas series to reindex
+    series2 : pd.Series
+        Pandas series to set the index of series1 by
+    """
+
+    df = pd.merge(pd.DataFrame({"left": series2}),
+                  pd.DataFrame({"right": series1}),
+                  left_on="left",
+                  right_index=True,
+                  how="left")
+    return df.right

--- a/pandana/utils.py
+++ b/pandana/utils.py
@@ -7,10 +7,14 @@ def reindex(series1, series2):
 
     Parameters
     ----------
-    series1 : pd.Series
+    series1 : pandas.Series
         Pandas series to reindex
-    series2 : pd.Series
+    series2 : pandas.Series
         Pandas series to set the index of series1 by
+
+    Returns
+    -------
+    df.right : pandas.DataFrame
     """
 
     df = pd.merge(pd.DataFrame({"left": series2}),

--- a/pandana/utils.py
+++ b/pandana/utils.py
@@ -17,6 +17,8 @@ def reindex(series1, series2):
     df.right : pandas.DataFrame
     """
 
+    # this function is identical to the reindex function found in UrbanSim in
+    # urbansim/utils/misc.py
     df = pd.merge(pd.DataFrame({"left": series2}),
                   pd.DataFrame({"right": series1}),
                   left_on="left",


### PR DESCRIPTION
Added a reindex function to utils.py. reindexing with pandana is common in order to merge cumulative accessibility results at the street node id with the original id from the variable of interest index.