### PR TITLE
Fixes dependency on numpy during installation process.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ use_setuptools()
 
 from setuptools import setup, Extension, find_packages
 from setuptools.command.test import test as TestCommand
-import numpy as np
+from setuptools.command.build_ext import build_ext
 
 
 class PyTest(TestCommand):
@@ -30,8 +30,15 @@ class PyTest(TestCommand):
         sys.exit(errno)
 
 
+class CustomBuildExtCommand(build_ext):
+    """build_ext command for use when numpy headers are needed."""
+    def run(self):
+        import numpy as np
+        self.include_dirs.append(np.get_include())
+        build_ext.run(self)
+
+
 include_dirs = [
-    np.get_include(),
     '.',
     'src/ann_1.1.2/include'
 ]
@@ -107,15 +114,13 @@ setup(
                  'dataframes of network queries, quickly'),
     long_description=long_description,
     url='https://udst.github.io/pandana/',
-    ext_modules=[
-        Extension(
+    ext_modules=[Extension(
             'pandana._pyaccess',
             source_files,
             include_dirs=include_dirs,
             extra_compile_args=extra_compile_args,
-            extra_link_args=extra_link_args
-        )
-    ],
+            extra_link_args=extra_link_args,
+        )],
     install_requires=[
         'matplotlib>=1.3.1',
         'numpy>=1.8.0',
@@ -125,7 +130,10 @@ setup(
         'osmnet>=0.1.2',
     ],
     tests_require=['pytest'],
-    cmdclass={'test': PyTest},
+    cmdclass={
+        'test': PyTest,
+        'build_ext': CustomBuildExtCommand,
+    },
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Programming Language :: Python :: 2.7',


### PR DESCRIPTION
Fixes  #74. This allows `pandana` to be installed on a system that does not already have `numpy` installed.

Because of calls to `import numpy as np` and `np.get_include()` the `setup.py` for this package has a hard dependency on `numpy` already being installed even though it lists it as a dependency as part of `install_requires` for the package. This change makes it so that `numpy` gets installed prior to it being imported.

Here's what happens on a Debian system with Python 3.5.2 when you try to install the package prior to this patch:
```
root@303f74e508c8:/code# pip install .
Processing /code
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-0tyxs_px-build/setup.py", line 11, in <module>
        import numpy as np
    ImportError: No module named 'numpy'

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-0tyxs_px-build/
```

Here's what happens after this patch:
```
root@303f74e508c8:/code# pip install .
Processing /code
Collecting matplotlib>=1.3.1 (from pandana==0.3.0)
  Downloading matplotlib-2.0.2-cp35-cp35m-manylinux1_x86_64.whl (14.6MB)
    100% |████████████████████████████████| 14.6MB 113kB/s
Collecting numpy>=1.8.0 (from pandana==0.3.0)
  Downloading numpy-1.12.1-cp35-cp35m-manylinux1_x86_64.whl (16.8MB)
    100% |████████████████████████████████| 16.8MB 102kB/s
Collecting pandas>=0.17.0 (from pandana==0.3.0)
  Downloading pandas-0.20.1-cp35-cp35m-manylinux1_x86_64.whl (24.0MB)
    100% |████████████████████████████████| 24.0MB 70kB/s
Collecting requests>=2.0 (from pandana==0.3.0)
  Downloading requests-2.14.2-py2.py3-none-any.whl (560kB)
    100% |████████████████████████████████| 563kB 2.6MB/s
Collecting tables>=3.1.0 (from pandana==0.3.0)
  Downloading tables-3.4.2-3-cp35-cp35m-manylinux1_x86_64.whl (4.6MB)
    100% |████████████████████████████████| 4.6MB 375kB/s
Collecting osmnet>=0.1.2 (from pandana==0.3.0)
  Downloading osmnet-0.1.4-py2.py3-none-any.whl
Collecting six>=1.10 (from matplotlib>=1.3.1->pandana==0.3.0)
  Downloading six-1.10.0-py2.py3-none-any.whl
Collecting cycler>=0.10 (from matplotlib>=1.3.1->pandana==0.3.0)
  Downloading cycler-0.10.0-py2.py3-none-any.whl
Collecting python-dateutil (from matplotlib>=1.3.1->pandana==0.3.0)
  Downloading python_dateutil-2.6.0-py2.py3-none-any.whl (194kB)
    100% |████████████████████████████████| 194kB 4.8MB/s
Collecting pyparsing!=2.0.0,!=2.0.4,!=2.1.2,!=2.1.6,>=1.5.6 (from matplotlib>=1.3.1->pandana==0.3.0)
  Downloading pyparsing-2.2.0-py2.py3-none-any.whl (56kB)
    100% |████████████████████████████████| 61kB 5.8MB/s
Collecting pytz (from matplotlib>=1.3.1->pandana==0.3.0)
  Downloading pytz-2017.2-py2.py3-none-any.whl (484kB)
    100% |████████████████████████████████| 491kB 2.9MB/s
Collecting numexpr>=2.5.2 (from tables>=3.1.0->pandana==0.3.0)
  Downloading numexpr-2.6.2-cp35-cp35m-manylinux1_x86_64.whl (377kB)
    100% |████████████████████████████████| 378kB 3.5MB/s
Collecting Shapely>=1.5 (from osmnet>=0.1.2->pandana==0.3.0)
  Downloading Shapely-1.5.17.post1-cp35-cp35m-manylinux1_x86_64.whl (8.3MB)
    100% |████████████████████████████████| 8.3MB 203kB/s
Collecting geopandas>=0.2.1 (from osmnet>=0.1.2->pandana==0.3.0)
  Downloading geopandas-0.2.1-py2.py3-none-any.whl (199kB)
    100% |████████████████████████████████| 204kB 4.5MB/s
Collecting fiona (from geopandas>=0.2.1->osmnet>=0.1.2->pandana==0.3.0)
  Downloading Fiona-1.7.6-cp35-cp35m-manylinux1_x86_64.whl (39.8MB)
    100% |████████████████████████████████| 39.8MB 42kB/s
Collecting pyproj (from geopandas>=0.2.1->osmnet>=0.1.2->pandana==0.3.0)
  Downloading pyproj-1.9.5.1.tar.gz (4.4MB)
    100% |████████████████████████████████| 4.4MB 359kB/s
Collecting descartes (from geopandas>=0.2.1->osmnet>=0.1.2->pandana==0.3.0)
  Downloading descartes-1.1.0-py3-none-any.whl
Collecting munch (from fiona->geopandas>=0.2.1->osmnet>=0.1.2->pandana==0.3.0)
  Downloading munch-2.1.1.tar.gz
Collecting cligj (from fiona->geopandas>=0.2.1->osmnet>=0.1.2->pandana==0.3.0)
  Downloading cligj-0.4.0-py3-none-any.whl
Collecting click-plugins (from fiona->geopandas>=0.2.1->osmnet>=0.1.2->pandana==0.3.0)
  Downloading click-plugins-1.0.3.tar.gz
Collecting click>=4.0 (from cligj->fiona->geopandas>=0.2.1->osmnet>=0.1.2->pandana==0.3.0)
  Downloading click-6.7-py2.py3-none-any.whl (71kB)
    100% |████████████████████████████████| 71kB 3.4MB/s
Installing collected packages: numpy, six, cycler, python-dateutil, pyparsing, pytz, matplotlib, pandas, requests, numexpr, tables, Shapely, munch, click, cligj, click-plugins, fiona, pyproj, descartes, geopandas, osmnet, pandana
  Running setup.py install for munch ... done
  Running setup.py install for click-plugins ... done
  Running setup.py install for pyproj ... done
  Running setup.py install for pandana ... done
Successfully installed Shapely-1.5.17.post1 click-6.7 click-plugins-1.0.3 cligj-0.4.0 cycler-0.10.0 descartes-1.1.0 fiona-1.7.6 geopandas-0.2.1 matplotlib-2.0.2 munch-2.1.1 numexpr-2.6.2 numpy-1.12.1 osmnet-0.1.4 pandana-0.3.0 pandas-0.20.1 pyparsing-2.2.0 pyproj-1.9.5.1 python-dateutil-2.6.0 pytz-2017.2 requests-2.14.2 six-1.10.0 tables-3.4.2
```

All credit for this fix goes to the author of this StackOverflow answer:
http://stackoverflow.com/a/42163080