### PR TITLE
Issue 73

### DIFF
--- a/pandana/network.py
+++ b/pandana/network.py
@@ -633,7 +633,7 @@ class Network:
                 # intuitive to the user I think
                 s = df2[col].astype('int')
                 df2[col] = self.poi_category_indexes[category].values[s]
-                df2[col][s == -1] = np.nan
+                df2.loc[s == -1, col] = np.nan
 
             df = pd.concat([df, df2], axis=1)
 

--- a/pandana/tests/test_pandana.py
+++ b/pandana/tests/test_pandana.py
@@ -255,4 +255,51 @@ def test_pois2(second_sample_osm):
 
     net2.set_pois("restaurants", x, y)
 
-    print(net2.nearest_pois(2000, "restaurants", num_pois=10))
+
+# test sorting isn't needed - there was code in the cpp that sorted based on distance
+def test_sorted_pois(sample_osm):
+    net = sample_osm
+    net.init_pois(num_categories=1, max_dist=2000, max_pois=10)
+
+    ssize = 1000
+    x, y = random_x_y(sample_osm, ssize)
+
+    # set two categories
+    net.set_pois("restaurants", x, y)
+
+    test = net.nearest_pois(2000, "restaurants", num_pois=10)
+
+    for ind, row in test.iterrows():
+        # make sure it's sorted
+        assert_allclose(row, row.sort_values())
+
+
+def test_repeat_pois(sample_osm):
+    net = sample_osm
+    net.init_pois(num_categories=1, max_dist=2000, max_pois=10)
+
+    def get_nearest_nodes(x, y, x2=None, y2=None, n=2):
+        coords_dict = [{'x': x, 'y': y, 'var': 1} for i in range(2)]
+        if x2 and y2:
+            coords_dict.append({'x': x2, 'y': y2, 'var': 1})
+        df = pd.DataFrame(coords_dict)
+        sample_osm.set_pois("restaurants", df['x'], df['y'])
+        res = sample_osm.nearest_pois(2000, "restaurants", num_pois=5, include_poi_ids=True)
+        return res
+
+    # these are the min-max values of the network
+    # -122.3383688 -122.2962223
+    # 47.5950005 47.6150548
+
+    test1 = get_nearest_nodes(-122.31, 47.60)
+    test2 = get_nearest_nodes(-122.254116, 37.869361)
+    # Same coords as the first call, should yield same result
+    test3 = get_nearest_nodes(-122.31, 47.60)
+    assert test1.equals(test3)
+
+    test4 = get_nearest_nodes(-122.31, 47.60, -122.32, 47.61, n=3)
+    assert_allclose(test4.loc[53114882], [7, 13, 13, 2000, 2000, 2, 0, 1, np.nan, np.nan])
+    assert_allclose(test4.loc[53114880], [6, 14, 14, 2000, 2000, 2, 0, 1, np.nan, np.nan])
+    assert_allclose(
+        test4.loc[53227769],
+        [2000, 2000, 2000, 2000, 2000, np.nan, np.nan, np.nan, np.nan, np.nan])

--- a/src/accessibility.cpp
+++ b/src/accessibility.cpp
@@ -37,6 +37,8 @@ namespace MTC {
             // initialize for all subgraphs
             for(int i = 0 ; i < ga.size() ; i++) {
 			    ga[i]->initPOIs(numcategories, maxdist, maxitems);
+			    this->maxdist = maxdist;
+			    this->maxitems = maxitems;
             }
 			accessibilityVarsForPOIs.resize(numcategories);
 		}
@@ -46,6 +48,15 @@ namespace MTC {
 
 			assert(vars.size() == numnodes);
 			accessibilityVarsForPOIs[category] = vars;
+
+			// initializePOIs should have already been called
+			assert(this->maxdist > 0);
+			assert(this->maxitems > 0);
+
+			// reinitialize this category bucket
+			for(int k = 0 ; k < ga.size() ; k++) {
+				ga[k]->initPOIIndex(category, this->maxdist, this->maxitems);
+			}
 
 			int cnt = 0;
 			for(int i = 0 ; i < vars.size() ; i++) {
@@ -94,8 +105,6 @@ namespace MTC {
 				double 	distance = itDist->second;
 
 				for(int i = 0 ; i < vars[nodeid].size() ; i++) {
-
-					if(vars[nodeid][i] == 0) continue;
 
 					if(return_nodeids) {
 						ret.push_back((float)vars[nodeid][i]);

--- a/src/accessibility.h
+++ b/src/accessibility.h
@@ -112,6 +112,8 @@ namespace MTC {
 			int numnodes;
 
 		private:
+			double maxdist;
+			int maxitems;
 			double compute_centrality(int srcnode, DistanceVec &distances,
 											 int graphno=0);
 			double compute_street_design_var(DistanceVec &distances,

--- a/src/contraction_hierarchies/src/libch.cpp
+++ b/src/contraction_hierarchies/src/libch.cpp
@@ -304,6 +304,12 @@ inline ostream& operator<< (ostream& os, const Edge& e) {
             poiIndexArray.push_back(CHPOIIndex(this->staticGraph, maxDistanceToConsider, maxNumberOfPOIsInBucket, numberOfThreads));
         }
     }
+
+    void ContractionHierarchies::createPOIIndex(unsigned categoryNum, unsigned maxDistanceToConsider, unsigned maxNumberOfPOIsInBucket){
+        CHASSERT(this->staticGraph != NULL, "Preprocessing not finished");
+        // reinitialize this bucket
+        poiIndexArray[categoryNum] = CHPOIIndex(this->staticGraph, maxDistanceToConsider, maxNumberOfPOIsInBucket, numberOfThreads);
+    }
     
     void ContractionHierarchies::addPOIToIndex(unsigned category, NodeID node) {
         CHASSERT(this->staticGraph != NULL, "Preprocessing not finished");

--- a/src/contraction_hierarchies/src/libch.cpp
+++ b/src/contraction_hierarchies/src/libch.cpp
@@ -307,6 +307,7 @@ inline ostream& operator<< (ostream& os, const Edge& e) {
 
     void ContractionHierarchies::createPOIIndex(unsigned categoryNum, unsigned maxDistanceToConsider, unsigned maxNumberOfPOIsInBucket){
         CHASSERT(this->staticGraph != NULL, "Preprocessing not finished");
+        CHASSERT(categoryNum < poiIndexArray.size(), "POI Category is out of Bounds");
         // reinitialize this bucket
         poiIndexArray[categoryNum] = CHPOIIndex(this->staticGraph, maxDistanceToConsider, maxNumberOfPOIsInBucket, numberOfThreads);
     }

--- a/src/contraction_hierarchies/src/libch.h
+++ b/src/contraction_hierarchies/src/libch.h
@@ -121,6 +121,7 @@ typedef std::vector<std::pair<NodeID, unsigned> > ReachedNode;
         void computeReachableNodesWithin(const Node &s, unsigned maxDistance, std::vector<std::pair<NodeID, unsigned> > & ResultingNodes);
         void computeReachableNodesWithin(const Node &s, unsigned maxDistance, std::vector<std::pair<NodeID, unsigned> > & ResultingNodes, unsigned threadID);
         void createPOIIndexArray(unsigned numberOfPOICategories, unsigned _maxDistanceToConsider, unsigned _maxNumberOfPOIsInBucket);
+        void createPOIIndex(unsigned categoryNum, unsigned _maxDistanceToConsider, unsigned _maxNumberOfPOIsInBucket);
         void addPOIToIndex(unsigned category, NodeID node);
         void getNearest(unsigned category, NodeID node, std::vector<BucketEntry>& resultingVenues);
         void getNearest(unsigned category, NodeID node, std::vector<BucketEntry>& resultingVenues, unsigned threadID);

--- a/src/graphalg.h
+++ b/src/graphalg.h
@@ -40,6 +40,10 @@ namespace MTC {
 				ch.createPOIIndexArray(numcategories, maxdist*DISTANCEMULTFACT,
 									   maxitems);
 			}
+			void initPOIIndex(int categoryNum, double maxdist, int maxitems) {
+				ch.createPOIIndex(categoryNum, maxdist*DISTANCEMULTFACT,
+									   maxitems);
+			}
 			void addPOIToIndex(int category, int i) {
 				ch.addPOIToIndex(category,i);
 			}


### PR DESCRIPTION
This, I am hoping fixes #73.

There were two things broken here.  First, when calling set_pois, we call the underlying set_pois routine in CH, which doesn't actually re-initialize the category, it just adds pois.  This is not what was expected so I had to add the code to re-initialize.  This behavior has actually been around since day 1.

Second, the code from 2 years ago which returned poi ids in addition to poi distances introduced a bug which doesn't return the first poi id encountered, which is a fairly egregious error.

@pksohn unfortunately because of this last one, I think we will have to cut a new release of pandana once we get this PR merged.