### PR TITLE
Remove the need of POI initialization call

### DIFF
--- a/docs/loaders.rst
+++ b/docs/loaders.rst
@@ -32,8 +32,7 @@ This can be used to populate a network with points of interest::
 
     nodes = osm.node_query(
         37.859, -122.282, 37.881, -122.252, tags='"amenity"="restaurant"')
-    network.init_pois(num_categories=1, max_dist=2000, max_pois=10)
-    network.set_pois('restaurants', nodes['lon'], nodes['lat'])
+    network.set_pois('restaurants', 2000, 10, nodes['lon'], nodes['lat'])
 
 For more about tags see the
 `Overpass API Language Guide <http://wiki.openstreetmap.org/wiki/Overpass_API/Language_Guide>`__

--- a/docs/network.rst
+++ b/docs/network.rst
@@ -1,5 +1,14 @@
 Network API
 -----------
 
+API changes: migration notes from version 3.0 to 4.0
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Starting on version 4.0, calls to ``init_pois`` are no longer necessary due to an improvement in the
+C++ backend. From that version on, the ``max_distance`` and the ``max_pois`` parameters are directly
+specified by category in the :py:meth:`pandana.network.Network.set_pois` call.
+
+
+
 .. automodule:: pandana.network
    :members:

--- a/docs/network.rst
+++ b/docs/network.rst
@@ -4,11 +4,11 @@ Network API
 API changes: migration notes from version 3.0 to 4.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Starting on version 4.0, calls to ``init_pois`` are no longer necessary due to an improvement in the
+Starting with version 4.0, calls to ``init_pois`` are no longer necessary due to an improvement in the
 C++ backend. From that version on, the ``max_distance`` and the ``max_pois`` parameters are directly
 specified by category in the :py:meth:`pandana.network.Network.set_pois` call.
 
-
+The ``reserve_num_graphs`` call is also no longer required.  Pandana Network objects can now be created and destroyed on-the-fly and no initialization need be done in advance.
 
 .. automodule:: pandana.network
    :members:

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -92,24 +92,13 @@ Assign variables and perform computations for nearest queries
 Now for the fun part.  Nearest queries are slightly easier, so let's cover that
 first.
 
-First initialize the POI (point-of-interest) engine.  This is a bit
-strange for Python programmers, but because this code wraps a C++ API,
-you need to initialize the memory first.  This is not a strict requirement
-though, and future versions might remedy this. ::
+First initialize the POI (point-of-interest) category: ::
 
-    net.init_pois(num_categories=1, max_dist=2000, max_pois=10)
-
-This initializes one category, at a max distance of 2000 meters for up to the
-10 nearest points-of-interest.
-
-Here is a link to the docs: :py:meth:`pandana.network.Network.init_pois`
-
-Next initialize the category: ::
-
-    net.set_pois("restaurants", x, y)
+    net.set_pois("restaurants", 2000, 10, x, y)
 
 This code initializes the "restaurants" category with the positions specified
-by the x and y columns (which are Pandas Series).  Next perform the query:
+by the x and y columns (which are Pandas Series), at a max distance of 2000 meters
+for up to the 10 nearest points-of-interest.  Next perform the query:
 
 Here is a link to the docs: :py:meth:`pandana.network.Network.set_pois` ::
 

--- a/pandana/network.py
+++ b/pandana/network.py
@@ -454,7 +454,7 @@ class Network:
 
         return bmap, fig, ax
 
-    def set_pois(self, maxdist, maxitems, category, x_col, y_col):
+    def set_pois(self, category, maxdist, maxitems, x_col, y_col):
         """
         Set the location of all the pois of this category. The pois are
         connected to the closest node in the Pandana network which assumes
@@ -463,12 +463,12 @@ class Network:
 
         Parameters
         ----------
+        category : string
+            The name of the category for this set of pois
         maxdist - the maximum distance that will later be used in
             find_all_nearest_pois
         maxitems - the maximum number of items that will later be requested
             in find_all_nearest_pois
-        category : string
-            The name of the category for this set of pois
         x_col : Pandas Series (float)
             The x location (longitude) of pois in this category
         y_col : Pandas Series (Float)

--- a/pandana/network.py
+++ b/pandana/network.py
@@ -454,29 +454,8 @@ class Network:
 
         return bmap, fig, ax
 
-    def init_pois(self, max_dist, max_pois):
-        """
-        Initialize the point of interest infrastructure.
 
-        Parameters
-        ----------
-        max_dist : float
-            Maximum distance that will be tested to nearest POIs. This will
-            usually be a distance unit in meters however if you have
-            customized the impedance this could be in other
-            units such as utility or time etc.
-        max_pois :
-            Maximum number of POIs to return in the nearest query
-
-        Returns
-        -------
-        Nothing
-        """
-        self.max_pois = max_pois
-
-        self.net.initialize_pois(max_dist, max_pois)
-
-    def set_pois(self, category, x_col, y_col):
+    def set_pois(self, maxdist, maxitems, category, x_col, y_col):
         """
         Set the location of all the pois of this category. The pois are
         connected to the closest node in the Pandana network which assumes
@@ -485,6 +464,10 @@ class Network:
 
         Parameters
         ----------
+        maxdist - the maximum distance that will later be used in
+            find_all_nearest_pois
+        maxitems - the maximum number of items that will later be requested
+            in find_all_nearest_pois
         category : string
             The name of the category for this set of pois
         x_col : Pandas Series (float)
@@ -499,13 +482,15 @@ class Network:
         if category not in self.poi_category_names:
             self.poi_category_names.append(category)
 
+        self.max_pois = maxitems
+
         node_ids = self.get_node_ids(x_col, y_col)
 
         self.poi_category_indexes[category] = node_ids.index
 
         node_idx = self._node_indexes(node_ids)
 
-        self.net.initialize_category(category, node_idx.values)
+        self.net.initialize_category(maxdist, maxitems, category, node_idx.values)
 
     def nearest_pois(self, distance, category, num_pois=1, max_distance=None,
                      imp_name=None, include_poi_ids=False):

--- a/pandana/network.py
+++ b/pandana/network.py
@@ -65,7 +65,6 @@ class Network:
         self.variable_names = set()
         self.poi_category_names = []
         self.poi_category_indexes = {}
-        self.num_poi_categories = -1
 
         # this maps ids to indexes which are used internally
         # this is a constant source of headaches, but all node identifiers
@@ -455,14 +454,12 @@ class Network:
 
         return bmap, fig, ax
 
-    def init_pois(self, num_categories, max_dist, max_pois):
+    def init_pois(self, max_dist, max_pois):
         """
         Initialize the point of interest infrastructure.
 
         Parameters
         ----------
-        num_categories : int
-            Number of categories of POIs
         max_dist : float
             Maximum distance that will be tested to nearest POIs. This will
             usually be a distance unit in meters however if you have
@@ -475,14 +472,9 @@ class Network:
         -------
         Nothing
         """
-        if self.num_poi_categories != -1:
-            print("Can't initialize twice")
-            return
-
-        self.num_poi_categories = num_categories
         self.max_pois = max_pois
 
-        self.net.initialize_pois(num_categories, max_dist, max_pois)
+        self.net.initialize_pois(max_dist, max_pois)
 
     def set_pois(self, category, x_col, y_col):
         """
@@ -504,13 +496,7 @@ class Network:
         -------
         Nothing
         """
-        if self.num_poi_categories == -1:
-            assert 0, "Need to call init_pois first"
-
         if category not in self.poi_category_names:
-            assert len(self.poi_category_names) < self.num_poi_categories, \
-                "Too many categories set - increase the number when calling " \
-                "init_pois"
             self.poi_category_names.append(category)
 
         node_ids = self.get_node_ids(x_col, y_col)
@@ -571,9 +557,6 @@ class Network:
         """
         if max_distance is None:
             max_distance = distance
-
-        if self.num_poi_categories == -1:
-            assert 0, "Need to call init_pois first"
 
         if category not in self.poi_category_names:
             assert 0, "Need to call set_pois for this category"

--- a/pandana/network.py
+++ b/pandana/network.py
@@ -519,8 +519,7 @@ class Network:
 
         node_idx = self._node_indexes(node_ids)
 
-        self.net.initialize_category(self.poi_category_names.index(category),
-                                     node_idx.values)
+        self.net.initialize_category(category, node_idx.values)
 
     def nearest_pois(self, distance, category, num_pois=1, max_distance=None,
                      imp_name=None, include_poi_ids=False):
@@ -587,7 +586,7 @@ class Network:
         dists, poi_ids = self.net.find_all_nearest_pois(
             distance,
             num_pois,
-            self.poi_category_names.index(category),
+            category,
             imp_num)
         dists[dists == -1] = max_distance
 

--- a/pandana/network.py
+++ b/pandana/network.py
@@ -236,7 +236,7 @@ class Network:
 
         self.variable_names.add(name)
 
-        self.net.initialize_access_var(name,
+        self.net.initialize_access_var(name.encode('utf-8'),
                                        df.node_idx.values.astype('int'),
                                        df[name].values)
 
@@ -327,9 +327,9 @@ class Network:
                                             "has not yet been initialized"
 
         res = self.net.get_all_aggregate_accessibility_variables(distance,
-                                                                 name,
-                                                                 type,
-                                                                 decay,
+                                                                 name.encode('utf-8'),
+                                                                 type.encode('utf-8'),
+                                                                 decay.encode('utf-8'),
                                                                  imp_num)
 
         return pd.Series(res, index=self.node_ids)
@@ -490,7 +490,7 @@ class Network:
 
         node_idx = self._node_indexes(node_ids)
 
-        self.net.initialize_category(maxdist, maxitems, category, node_idx.values)
+        self.net.initialize_category(maxdist, maxitems, category.encode('utf-8'), node_idx.values)
 
     def nearest_pois(self, distance, category, num_pois=1, max_distance=None,
                      imp_name=None, include_poi_ids=False):
@@ -554,7 +554,7 @@ class Network:
         dists, poi_ids = self.net.find_all_nearest_pois(
             distance,
             num_pois,
-            category,
+            category.encode('utf-8'),
             imp_num)
         dists[dists == -1] = max_distance
 

--- a/pandana/network.py
+++ b/pandana/network.py
@@ -454,7 +454,6 @@ class Network:
 
         return bmap, fig, ax
 
-
     def set_pois(self, maxdist, maxitems, category, x_col, y_col):
         """
         Set the location of all the pois of this category. The pois are

--- a/pandana/tests/test_cyaccess.py
+++ b/pandana/tests/test_cyaccess.py
@@ -68,8 +68,8 @@ def test_poi_analysis(net, nodes_and_edges):
     NUM_NODES = 30
     np.random.seed(0)
     random_node_ids = np.random.choice(np.arange(len(nodes)), NUM_NODES)
-    net.initialize_category(0, random_node_ids)
-    dists, poi_ids = net.find_all_nearest_pois(10, 3, 0)
+    net.initialize_category("0", random_node_ids)
+    dists, poi_ids = net.find_all_nearest_pois(10, 3, "0")
     df = pd.DataFrame(poi_ids)
     assert df.loc[0, 0] == 6
     assert df.loc[0, 1] == 25
@@ -77,7 +77,7 @@ def test_poi_analysis(net, nodes_and_edges):
     s = df[0].value_counts()
     assert s[-1] == 1081
     assert s[5] == 1
-    ret = net.find_all_nearest_pois(10, 3, 0)
+    ret = net.find_all_nearest_pois(10, 3, "0")
     df = pd.DataFrame(dists)
     assert df.loc[0, 0] == 4
     assert df.loc[0, 1] == 6

--- a/pandana/tests/test_cyaccess.py
+++ b/pandana/tests/test_cyaccess.py
@@ -51,14 +51,14 @@ def test_agg_analysis(net, nodes_and_edges):
     np.random.seed(0)
     random_node_ids = np.random.choice(np.arange(len(nodes)), NUM_NODES)
     random_vals = np.random.random(NUM_NODES) * 100
-    net.initialize_access_var("test", random_node_ids, random_vals)
-    ret = net.get_all_aggregate_accessibility_variables(10, "test", "sum", "flat")
+    net.initialize_access_var(b'test', random_node_ids, random_vals)
+    ret = net.get_all_aggregate_accessibility_variables(10, b'test', b'sum', b'flat')
     ret = pd.Series(ret)
     assert_almost_equal(ret[0], 159.208338, decimal=4)
     assert_almost_equal(ret[50], 94.466888, decimal=4)
 
     # test missing aggregation type
-    ret = net.get_all_aggregate_accessibility_variables(10, "test", "this is", "bogus")
+    ret = net.get_all_aggregate_accessibility_variables(10, b'test', b'this is', b'bogus')
     assert np.alltrue(np.isnan(ret))
 
 
@@ -67,8 +67,8 @@ def test_poi_analysis(net, nodes_and_edges):
     NUM_NODES = 30
     np.random.seed(0)
     random_node_ids = np.random.choice(np.arange(len(nodes)), NUM_NODES)
-    net.initialize_category(10, 3, "0", random_node_ids)
-    dists, poi_ids = net.find_all_nearest_pois(10, 3, "0")
+    net.initialize_category(10, 3, b'0', random_node_ids)
+    dists, poi_ids = net.find_all_nearest_pois(10, 3, b'0')
     df = pd.DataFrame(poi_ids)
     assert df.loc[0, 0] == 6
     assert df.loc[0, 1] == 25
@@ -76,7 +76,7 @@ def test_poi_analysis(net, nodes_and_edges):
     s = df[0].value_counts()
     assert s[-1] == 1081
     assert s[5] == 1
-    ret = net.find_all_nearest_pois(10, 3, "0")
+    ret = net.find_all_nearest_pois(10, 3, b'0')
     df = pd.DataFrame(dists)
     assert df.loc[0, 0] == 4
     assert df.loc[0, 1] == 6

--- a/pandana/tests/test_cyaccess.py
+++ b/pandana/tests/test_cyaccess.py
@@ -64,7 +64,7 @@ def test_agg_analysis(net, nodes_and_edges):
 
 def test_poi_analysis(net, nodes_and_edges):
     nodes = nodes_and_edges[0]
-    net.initialize_pois(1, 10, 3)
+    net.initialize_pois(10, 3)
     NUM_NODES = 30
     np.random.seed(0)
     random_node_ids = np.random.choice(np.arange(len(nodes)), NUM_NODES)

--- a/pandana/tests/test_cyaccess.py
+++ b/pandana/tests/test_cyaccess.py
@@ -64,11 +64,10 @@ def test_agg_analysis(net, nodes_and_edges):
 
 def test_poi_analysis(net, nodes_and_edges):
     nodes = nodes_and_edges[0]
-    net.initialize_pois(10, 3)
     NUM_NODES = 30
     np.random.seed(0)
     random_node_ids = np.random.choice(np.arange(len(nodes)), NUM_NODES)
-    net.initialize_category("0", random_node_ids)
+    net.initialize_category(10, 3, "0", random_node_ids)
     dists, poi_ids = net.find_all_nearest_pois(10, 3, "0")
     df = pd.DataFrame(poi_ids)
     assert df.loc[0, 0] == 6

--- a/pandana/tests/test_pandana.py
+++ b/pandana/tests/test_pandana.py
@@ -173,9 +173,8 @@ def test_agg_variables(sample_osm):
     for type in net.aggregations:
         for decay in net.decays:
             for distance in [5, 10, 20]:
-                t = type.decode(encoding='UTF-8') #(type) #,'utf-8')
-                d = decay.decode(encoding='UTF-8') #(type) #,'utf-8')
-                #d = str(decay)# ,'utf-8')
+                t = type.decode(encoding='UTF-8')
+                d = decay.decode(encoding='UTF-8')
                 s = net.aggregate(distance, type=t, decay=d)
                 assert s.describe()['std'] > 0
 
@@ -186,8 +185,8 @@ def test_agg_variables(sample_osm):
     for type in net.aggregations:
         for decay in net.decays:
             for distance in [5, 10, 20]:
-                t = type.decode(encoding='UTF-8') #(type) #,'utf-8')
-                d = decay.decode(encoding='UTF-8') #(type) #,'utf-8')
+                t = type.decode(encoding='UTF-8')
+                d = decay.decode(encoding='UTF-8')
                 s = net.aggregate(distance, type=t, decay=d)
                 if t != "std":
                     assert s.describe()['std'] > 0

--- a/pandana/tests/test_pandana.py
+++ b/pandana/tests/test_pandana.py
@@ -271,7 +271,7 @@ def test_pois(sample_osm):
         net.nearest_pois(2000, "restaurants", num_pois=10)
 
     # boundary condition
-    net.set_pois(2000, 10, "restaurants", x, y)
+    net.set_pois("restaurants", 2000, 10, x, y)
 
     net.nearest_pois(2000, "restaurants", num_pois=10)
 
@@ -283,7 +283,7 @@ def test_pois(sample_osm):
     x.index = ['lab%d' % i for i in range(len(x))]
     y.index = x.index
 
-    net.set_pois(2000, 10, "restaurants", x, y)
+    net.set_pois("restaurants", 2000, 10, x, y)
 
     d = net.nearest_pois(2000, "restaurants", num_pois=10,
                          include_poi_ids=True)
@@ -297,7 +297,7 @@ def test_pois2(second_sample_osm):
     x, y = random_x_y(second_sample_osm, ssize)
 
     # make sure poi searches work on second graph
-    net2.set_pois(2000, 10, "restaurants", x, y)
+    net2.set_pois("restaurants", 2000, 10, x, y)
 
     net2.nearest_pois(2000, "restaurants", num_pois=10)
 
@@ -310,7 +310,7 @@ def test_sorted_pois(sample_osm):
     x, y = random_x_y(sample_osm, ssize)
 
     # set two categories
-    net.set_pois(2000, 10, "restaurants", x, y)
+    net.set_pois("restaurants", 2000, 10, x, y)
 
     test = net.nearest_pois(2000, "restaurants", num_pois=10)
 
@@ -327,7 +327,7 @@ def test_repeat_pois(sample_osm):
         if x2 and y2:
             coords_dict.append({'x': x2, 'y': y2, 'var': 1})
         df = pd.DataFrame(coords_dict)
-        sample_osm.set_pois(2000, 10, "restaurants", df['x'], df['y'])
+        sample_osm.set_pois("restaurants", 2000, 10, df['x'], df['y'])
         res = sample_osm.nearest_pois(2000, "restaurants", num_pois=5, include_poi_ids=True)
         return res
 

--- a/pandana/tests/test_pandana.py
+++ b/pandana/tests/test_pandana.py
@@ -173,7 +173,10 @@ def test_agg_variables(sample_osm):
     for type in net.aggregations:
         for decay in net.decays:
             for distance in [5, 10, 20]:
-                s = net.aggregate(distance, type=type, decay=decay)
+                t = type.decode(encoding='UTF-8') #(type) #,'utf-8')
+                d = decay.decode(encoding='UTF-8') #(type) #,'utf-8')
+                #d = str(decay)# ,'utf-8')
+                s = net.aggregate(distance, type=t, decay=d)
                 assert s.describe()['std'] > 0
 
     # testing w/o setting variable
@@ -183,8 +186,10 @@ def test_agg_variables(sample_osm):
     for type in net.aggregations:
         for decay in net.decays:
             for distance in [5, 10, 20]:
-                s = net.aggregate(distance, type=type, decay=decay)
-                if type != "std":
+                t = type.decode(encoding='UTF-8') #(type) #,'utf-8')
+                d = decay.decode(encoding='UTF-8') #(type) #,'utf-8')
+                s = net.aggregate(distance, type=t, decay=d)
+                if t != "std":
                     assert s.describe()['std'] > 0
                 else:
                     # no variance in data

--- a/pandana/tests/test_pandana.py
+++ b/pandana/tests/test_pandana.py
@@ -263,15 +263,11 @@ def test_pois(sample_osm):
     with pytest.raises(AssertionError):
         net.nearest_pois(2000, "restaurants", num_pois=10)
 
-    net.init_pois(max_dist=2000, max_pois=10)
-
     with pytest.raises(AssertionError):
         net.nearest_pois(2000, "restaurants", num_pois=10)
 
     # boundary condition
-    net.init_pois(max_dist=2000, max_pois=10)
-
-    net.set_pois("restaurants", x, y)
+    net.set_pois(2000, 10, "restaurants", x, y)
 
     net.nearest_pois(2000, "restaurants", num_pois=10)
 
@@ -283,7 +279,7 @@ def test_pois(sample_osm):
     x.index = ['lab%d' % i for i in range(len(x))]
     y.index = x.index
 
-    net.set_pois("restaurants", x, y)
+    net.set_pois(2000, 10, "restaurants", x, y)
 
     d = net.nearest_pois(2000, "restaurants", num_pois=10,
                          include_poi_ids=True)
@@ -297,9 +293,7 @@ def test_pois2(second_sample_osm):
     x, y = random_x_y(second_sample_osm, ssize)
 
     # make sure poi searches work on second graph
-    net2.init_pois(max_dist=2000, max_pois=10)
-
-    net2.set_pois("restaurants", x, y)
+    net2.set_pois(2000, 10, "restaurants", x, y)
 
     net2.nearest_pois(2000, "restaurants", num_pois=10)
 
@@ -307,13 +301,12 @@ def test_pois2(second_sample_osm):
 # test items are sorted
 def test_sorted_pois(sample_osm):
     net = sample_osm
-    net.init_pois(max_dist=2000, max_pois=10)
 
     ssize = 1000
     x, y = random_x_y(sample_osm, ssize)
 
     # set two categories
-    net.set_pois("restaurants", x, y)
+    net.set_pois(2000, 10, "restaurants", x, y)
 
     test = net.nearest_pois(2000, "restaurants", num_pois=10)
 
@@ -324,14 +317,13 @@ def test_sorted_pois(sample_osm):
 
 def test_repeat_pois(sample_osm):
     net = sample_osm
-    net.init_pois(max_dist=2000, max_pois=10)
 
     def get_nearest_nodes(x, y, x2=None, y2=None, n=2):
         coords_dict = [{'x': x, 'y': y, 'var': 1} for i in range(2)]
         if x2 and y2:
             coords_dict.append({'x': x2, 'y': y2, 'var': 1})
         df = pd.DataFrame(coords_dict)
-        sample_osm.set_pois("restaurants", df['x'], df['y'])
+        sample_osm.set_pois(2000, 10, "restaurants", df['x'], df['y'])
         res = sample_osm.nearest_pois(2000, "restaurants", num_pois=5, include_poi_ids=True)
         return res
 

--- a/pandana/tests/test_pandana.py
+++ b/pandana/tests/test_pandana.py
@@ -261,18 +261,15 @@ def test_pois(sample_osm):
     x, y = random_x_y(sample_osm, ssize)
 
     with pytest.raises(AssertionError):
-        net.set_pois("restaurants", x, y)
-
-    with pytest.raises(AssertionError):
         net.nearest_pois(2000, "restaurants", num_pois=10)
 
-    net.init_pois(num_categories=1, max_dist=2000, max_pois=10)
+    net.init_pois(max_dist=2000, max_pois=10)
 
     with pytest.raises(AssertionError):
         net.nearest_pois(2000, "restaurants", num_pois=10)
 
     # boundary condition
-    net.init_pois(num_categories=1, max_dist=2000, max_pois=10)
+    net.init_pois(max_dist=2000, max_pois=10)
 
     net.set_pois("restaurants", x, y)
 
@@ -300,7 +297,7 @@ def test_pois2(second_sample_osm):
     x, y = random_x_y(second_sample_osm, ssize)
 
     # make sure poi searches work on second graph
-    net2.init_pois(num_categories=1, max_dist=2000, max_pois=10)
+    net2.init_pois(max_dist=2000, max_pois=10)
 
     net2.set_pois("restaurants", x, y)
 
@@ -310,7 +307,7 @@ def test_pois2(second_sample_osm):
 # test items are sorted
 def test_sorted_pois(sample_osm):
     net = sample_osm
-    net.init_pois(num_categories=1, max_dist=2000, max_pois=10)
+    net.init_pois(max_dist=2000, max_pois=10)
 
     ssize = 1000
     x, y = random_x_y(sample_osm, ssize)
@@ -327,7 +324,7 @@ def test_sorted_pois(sample_osm):
 
 def test_repeat_pois(sample_osm):
     net = sample_osm
-    net.init_pois(num_categories=1, max_dist=2000, max_pois=10)
+    net.init_pois(max_dist=2000, max_pois=10)
 
     def get_nearest_nodes(x, y, x2=None, y2=None, n=2):
         coords_dict = [{'x': x, 'y': y, 'var': 1} for i in range(2)]

--- a/src/accessibility.cpp
+++ b/src/accessibility.cpp
@@ -128,29 +128,28 @@ Accessibility::findNearestPOIs(int srcnode, float maxradius, unsigned number,
         maxradius, number, omp_get_thread_num());
 
     vector<distance_node_pair> distance_node_pairs;
-    try {
-        accessibility_vars_t &vars = accessibilityVarsForPOIs.at(cat);
+    if(accessibilityVarsForPOIs.find(cat) == accessibilityVarsForPOIs.end())
+        return distance_node_pairs;
 
-        /* need to account for the possibility of having
-         multiple locations at single node */
-        for (DistanceMap::const_iterator itDist = distancesmap.begin();
-           itDist != distancesmap.end();
-           ++itDist) {
-          int nodeid = itDist->first;
-          double distance = itDist->second;
+    accessibility_vars_t &vars = accessibilityVarsForPOIs.at(cat);
 
-          for (int i = 0 ; i < vars[nodeid].size() ; i++) {
-              distance_node_pairs.push_back(
-                 make_pair(distance, vars[nodeid][i]));
-          }
-        }
+    /* need to account for the possibility of having
+     multiple locations at single node */
+    for (DistanceMap::const_iterator itDist = distancesmap.begin();
+       itDist != distancesmap.end();
+       ++itDist) {
+      int nodeid = itDist->first;
+      double distance = itDist->second;
 
-        std::sort(distance_node_pairs.begin(), distance_node_pairs.end(),
-                distance_node_pair_comparator);
-
-    } catch(const std::out_of_range &) {
-          // TODO: @ffernandez -- check what is a reasonable behavior
+      for (int i = 0 ; i < vars[nodeid].size() ; i++) {
+          distance_node_pairs.push_back(
+             make_pair(distance, vars[nodeid][i]));
+      }
     }
+
+    std::sort(distance_node_pairs.begin(), distance_node_pairs.end(),
+            distance_node_pair_comparator);
+
     return distance_node_pairs;
 }
 

--- a/src/accessibility.cpp
+++ b/src/accessibility.cpp
@@ -81,20 +81,16 @@ POI QUERIES
 #######################
 */
 
-void Accessibility::initializePOIs(
-    double maxdist,
-    int maxitems) {
-    // save this for when reinitializing the category
-    this->maxdist = maxdist;
-    this->maxitems = maxitems;
-}
 
-
-void Accessibility::initializeCategory(string category,
-                                       vector<long> node_idx)
+void Accessibility::initializeCategory(const double maxdist, const int maxitems,
+                                       string category, vector<long> node_idx)
 {
     accessibility_vars_t av;
     av.resize(this->numnodes);
+
+    this->maxdist = maxdist;
+    this->maxitems = maxitems;
+
     // initialize for all subgraphs
     for (int i = 0 ; i < ga.size() ; i++) {
         ga[i]->initPOIIndex(category, this->maxdist, this->maxitems);

--- a/src/accessibility.cpp
+++ b/src/accessibility.cpp
@@ -82,16 +82,11 @@ POI QUERIES
 */
 
 void Accessibility::initializePOIs(
-    int numcategories,
     double maxdist,
     int maxitems) {
     // save this for when reinitializing the category
     this->maxdist = maxdist;
     this->maxitems = maxitems;
-    // initialize for all subgraphs
-    for (int i = 0 ; i < ga.size() ; i++) {
-        ga[i]->initPOIs(numcategories, maxdist, maxitems);
-    }
 }
 
 

--- a/src/accessibility.h
+++ b/src/accessibility.h
@@ -26,10 +26,7 @@ class Accessibility {
         bool twoway);
 
     // set how many POI categories there will be
-    void initializePOIs(
-        int numcategories,
-        double maxdist,
-        int maxitems);
+    void initializePOIs(double maxdist, int maxitems);
 
     // initialize the category number with POIs at the node_id locations
     void initializeCategory(string category, vector<long> node_idx);

--- a/src/accessibility.h
+++ b/src/accessibility.h
@@ -32,20 +32,15 @@ class Accessibility {
         int maxitems);
 
     // initialize the category number with POIs at the node_id locations
-    void initializeCategory(int category, vector<long> node_idx);
+    void initializeCategory(string category, vector<long> node_idx);
 
     // find the nearest pois for all nodes in the network
     pair<vector<vector<double>>, vector<vector<int>>>
-    findAllNearestPOIs(
-        float maxradius,
-        unsigned maxnumber,
-        unsigned cat,
-        int graphno = 0);
+    findAllNearestPOIs(float maxradius, unsigned maxnumber,
+                       string category, int graphno = 0);
 
-    void initializeAccVar(
-        string category,
-        vector<long> node_idx,
-        vector<double> values);
+    void initializeAccVar(string category, vector<long> node_idx,
+                          vector<double> values);
 
     // computes the accessibility for every node in the network
     vector<double>
@@ -107,7 +102,7 @@ class Accessibility {
     // set to one, but I can imagine using floating point values
     // here eventually - e.g. find the 3 nearest values similar to
     // a knn tree in 2D space
-    vector<accessibility_vars_t> accessibilityVarsForPOIs;
+    std::map<POIKeyType, accessibility_vars_t> accessibilityVarsForPOIs;
 
     // this stores the nodes within a certain range - we have the option
     // of precomputing all the nodes in a radius if we're going to make
@@ -120,12 +115,8 @@ class Accessibility {
     void addGraphalg(MTC::accessibility::Graphalg *g);
 
     vector<pair<double, int>>
-    findNearestPOIs(
-        int srcnode,
-        float maxradius,
-        unsigned maxnumber,
-        unsigned cat,
-        int graphno = 0);
+    findNearestPOIs(int srcnode, float maxradius, unsigned maxnumber,
+                    string cat, int graphno = 0);
 
     // aggregate a variable within a radius
     double

--- a/src/accessibility.h
+++ b/src/accessibility.h
@@ -25,11 +25,8 @@ class Accessibility {
         vector< vector<double> >  edgeweights,
         bool twoway);
 
-    // set how many POI categories there will be
-    void initializePOIs(double maxdist, int maxitems);
-
     // initialize the category number with POIs at the node_id locations
-    void initializeCategory(string category, vector<long> node_idx);
+    void initializeCategory(const double maxdist, const int maxitems, string category, vector<long> node_idx);
 
     // find the nearest pois for all nodes in the network
     pair<vector<vector<double>>, vector<vector<int>>>

--- a/src/contraction_hierarchies/src/libch.cpp
+++ b/src/contraction_hierarchies/src/libch.cpp
@@ -302,22 +302,32 @@ inline ostream& operator<< (ostream& os, const Edge& e) {
         CHASSERT(poiIndexMap.size() == 0, "POIIndex initialized before")
         
         for(unsigned i = 0; i < numberOfPOICategories; ++i) {
-            poiIndexMap[std::to_string(i)] = (CHPOIIndex(this->staticGraph, maxDistanceToConsider, maxNumberOfPOIsInBucket, numberOfThreads));
+            poiIndexMap.insert(CHPOIIndexMap::value_type(std::to_string(i),
+                                                         CHPOIIndex(this->staticGraph, maxDistanceToConsider,
+                                                                    maxNumberOfPOIsInBucket, numberOfThreads)));
         }
     }
 
 
-    void ContractionHierarchies::createPOIIndex(const POIKeyType &category, unsigned maxDistanceToConsider, unsigned maxNumberOfPOIsInBucket){
+    void ContractionHierarchies::createPOIIndex(const POIKeyType &category, unsigned maxDistanceToConsider,
+                                                unsigned maxNumberOfPOIsInBucket)
+    {
          CHASSERT(this->staticGraph != NULL, "Preprocessing not finished");
 
          // reinitialize this bucket
-         poiIndexMap[category] = CHPOIIndex(this->staticGraph, maxDistanceToConsider, maxNumberOfPOIsInBucket, numberOfThreads);
-    }    
+         poiIndexMap.insert(CHPOIIndexMap::value_type(category, CHPOIIndex(this->staticGraph, maxDistanceToConsider,
+                                                                           maxNumberOfPOIsInBucket, numberOfThreads)));
+    }
     
 
-    void ContractionHierarchies::addPOIToIndex(const POIKeyType &category, NodeID node) {
-        CHASSERT(this->staticGraph != NULL, "Preprocessing not finished");        
-        poiIndexMap[category].addPOIToIndex(node);
+    void ContractionHierarchies::addPOIToIndex(const POIKeyType &category, NodeID node)
+    {
+        CHASSERT(this->staticGraph != NULL, "Preprocessing not finished");
+        try {
+            poiIndexMap.at(category).addPOIToIndex(node);
+        } catch(const std::out_of_range &) {
+            // TODO: @ffernandez -- define behavior in this case
+        }
     }
     
 

--- a/src/contraction_hierarchies/src/libch.cpp
+++ b/src/contraction_hierarchies/src/libch.cpp
@@ -323,43 +323,31 @@ inline ostream& operator<< (ostream& os, const Edge& e) {
     void ContractionHierarchies::addPOIToIndex(const POIKeyType &category, NodeID node)
     {
         CHASSERT(this->staticGraph != NULL, "Preprocessing not finished");
-        try {
+        if(poiIndexMap.find(category) != poiIndexMap.end())
             poiIndexMap.at(category).addPOIToIndex(node);
-        } catch(const std::out_of_range &) {
-            // TODO: @ffernandez -- define behavior in this case
-        }
     }
     
 
     void ContractionHierarchies::getNearest(const POIKeyType &category, NodeID node, std::vector<BucketEntry>& resultingVenues) {
         CHASSERT(this->staticGraph != NULL, "Preprocessing not finished");
-        try {
+        if(poiIndexMap.find(category) != poiIndexMap.end())
             poiIndexMap.at(category).getNearestPOIs(node, resultingVenues);
-        } catch(const std::out_of_range &) {
-            // TODO: @ffernandez -- define behavior in this case
-        }
     }
     
 
     void ContractionHierarchies::getNearestWithUpperBoundOnDistance(const POIKeyType &category, NodeID node, EdgeWeight maxDistance,
                                                                     std::vector<BucketEntry>& resultingVenues) {
         CHASSERT(this->staticGraph != NULL, "Preprocessing not finished");
-        try {
+        if(poiIndexMap.find(category) != poiIndexMap.end())
             poiIndexMap.at(category).getNearestPOIsWithUpperBoundOnDistance(node, maxDistance, resultingVenues);
-        } catch(const std::out_of_range &) {
-            // TODO: @ffernandez -- define behavior in this case
-        }
     }
 
 
     void ContractionHierarchies::getNearestWithUpperBoundOnLocations(const POIKeyType &category, NodeID node, unsigned maxLocations,
                                                                      std::vector<BucketEntry>& resultingVenues) {
         CHASSERT(this->staticGraph != NULL, "Preprocessing not finished");
-        try {
+        if(poiIndexMap.find(category) != poiIndexMap.end())
             poiIndexMap.at(category).getNearestPOIsWithUpperBoundOnLocations(node, maxLocations, resultingVenues);
-        } catch(const std::out_of_range &) {
-            // TODO: @ffernandez -- define behavior in this case
-        }
     }
     
 
@@ -367,11 +355,8 @@ inline ostream& operator<< (ostream& os, const Edge& e) {
                                                                                 EdgeWeight maxDistance, unsigned maxLocations,
                                                                                 std::vector<BucketEntry>& resultingVenues) {
         CHASSERT(this->staticGraph != NULL, "Preprocessing not finished");
-        try {
+        if(poiIndexMap.find(category) != poiIndexMap.end())
             poiIndexMap.at(category).getNearestPOIs(node, resultingVenues, maxDistance, maxLocations);
-        } catch(const std::out_of_range &) {
-            // TODO: @ffernandez -- define behavior in this case
-        }
     }
     
 
@@ -379,11 +364,8 @@ inline ostream& operator<< (ostream& os, const Edge& e) {
     void ContractionHierarchies::getNearest(const POIKeyType &category, NodeID node, std::vector<BucketEntry>& resultingVenues,
                                             unsigned threadID) {
         CHASSERT(this->staticGraph != NULL, "Preprocessing not finished");
-        try {
+        if(poiIndexMap.find(category) != poiIndexMap.end())
             poiIndexMap.at(category).getNearestPOIs(node, resultingVenues, threadID);
-        } catch(const std::out_of_range &) {
-            // TODO: @ffernandez -- define behavior in this case
-        }
     }
 
     
@@ -391,22 +373,16 @@ inline ostream& operator<< (ostream& os, const Edge& e) {
                                                                     EdgeWeight maxDistance, std::vector<BucketEntry>& resultingVenues,
                                                                     unsigned threadID) {
         CHASSERT(this->staticGraph != NULL, "Preprocessing not finished");
-        try {
+        if(poiIndexMap.find(category) != poiIndexMap.end())
             poiIndexMap.at(category).getNearestPOIsWithUpperBoundOnDistance(node, maxDistance, resultingVenues, threadID);
-        } catch(const std::out_of_range &) {
-            // TODO: @ffernandez -- define behavior in this case
-        }
     }
     
 
     void ContractionHierarchies::getNearestWithUpperBoundOnLocations(const POIKeyType &category, NodeID node, unsigned maxLocations,
                                                                      std::vector<BucketEntry>& resultingVenues, unsigned threadID) {
         CHASSERT(this->staticGraph != NULL, "Preprocessing not finished");
-        try {
+        if(poiIndexMap.find(category) != poiIndexMap.end())
             poiIndexMap.at(category).getNearestPOIsWithUpperBoundOnLocations(node, maxLocations, resultingVenues, threadID);
-        } catch(const std::out_of_range &) {
-            // TODO: @ffernandez -- define behavior in this case
-        }
     }
 
 
@@ -414,11 +390,8 @@ inline ostream& operator<< (ostream& os, const Edge& e) {
                                                                                 EdgeWeight maxDistance, unsigned maxLocations,
                                                                                 std::vector<BucketEntry>& resultingVenues, unsigned threadID) {
         CHASSERT(this->staticGraph != NULL, "Preprocessing not finished");
-        try {
+        if(poiIndexMap.find(category) != poiIndexMap.end())
             poiIndexMap.at(category).getNearestPOIs(node, resultingVenues, maxDistance, maxLocations, threadID);
-        } catch(const std::out_of_range &) {
-            // TODO: @ffernandez -- define behavior in this case
-        }
     }
 
 }

--- a/src/contraction_hierarchies/src/libch.cpp
+++ b/src/contraction_hierarchies/src/libch.cpp
@@ -296,23 +296,12 @@ inline ostream& operator<< (ostream& os, const Edge& e) {
 	}
     
     /** POI queries single threaded */
-    void ContractionHierarchies::createPOIIndexArray(unsigned numberOfPOICategories, unsigned maxDistanceToConsider,
-                                                     unsigned maxNumberOfPOIsInBucket){
- 		CHASSERT(this->staticGraph != NULL, "Preprocessing not finished");
-        CHASSERT(poiIndexMap.size() == 0, "POIIndex initialized before")
-        
-        for(unsigned i = 0; i < numberOfPOICategories; ++i) {
-            poiIndexMap.insert(CHPOIIndexMap::value_type(std::to_string(i),
-                                                         CHPOIIndex(this->staticGraph, maxDistanceToConsider,
-                                                                    maxNumberOfPOIsInBucket, numberOfThreads)));
-        }
-    }
-
-
     void ContractionHierarchies::createPOIIndex(const POIKeyType &category, unsigned maxDistanceToConsider,
                                                 unsigned maxNumberOfPOIsInBucket)
     {
          CHASSERT(this->staticGraph != NULL, "Preprocessing not finished");
+         if(poiIndexMap.find(category) != poiIndexMap.end())
+             poiIndexMap.erase(poiIndexMap.find(category));
 
          // reinitialize this bucket
          poiIndexMap.insert(CHPOIIndexMap::value_type(category, CHPOIIndex(this->staticGraph, maxDistanceToConsider,

--- a/src/contraction_hierarchies/src/libch.h
+++ b/src/contraction_hierarchies/src/libch.h
@@ -123,7 +123,6 @@ typedef std::vector<std::pair<NodeID, unsigned> > ReachedNode;
         void computeReachableNodesWithin(const Node &s, unsigned maxDistance, std::vector<std::pair<NodeID, unsigned> > & ResultingNodes);
         void computeReachableNodesWithin(const Node &s, unsigned maxDistance, std::vector<std::pair<NodeID, unsigned> > & ResultingNodes, unsigned threadID);
 
-        void createPOIIndexArray(unsigned numberOfPOICategories, unsigned _maxDistanceToConsider, unsigned _maxNumberOfPOIsInBucket);
         void createPOIIndex(const POIKeyType &category, unsigned _maxDistanceToConsider, unsigned _maxNumberOfPOIsInBucket);
         void addPOIToIndex(const POIKeyType &category, NodeID node);
 

--- a/src/contraction_hierarchies/src/libch.h
+++ b/src/contraction_hierarchies/src/libch.h
@@ -25,6 +25,7 @@ or see http://www.gnu.org/licenses/agpl.txt.
 #include <iostream>
 #include <string>
 #include <vector>
+#include <map>
 
 #include "BasicDefinitions.h"
 #include "Contractor/ContractionCleanup.h"
@@ -46,7 +47,8 @@ typedef StaticGraph< EdgeData > QueryGraph;
 typedef vector<SimpleCHQuery<EdgeData, QueryGraph, Heap> > QueryObjectVector;
 
 typedef CH::POIIndex< QueryGraph > CHPOIIndex;
-typedef vector<CHPOIIndex> CHPOIIndexArray;
+typedef std::string POIKeyType;
+typedef std::map<POIKeyType, CHPOIIndex> CHPOIIndexMap;
 
 namespace CH {
 
@@ -120,18 +122,26 @@ typedef std::vector<std::pair<NodeID, unsigned> > ReachedNode;
         int computeVerificationLengthofShortestPath(const Node &s, const Node& t);
         void computeReachableNodesWithin(const Node &s, unsigned maxDistance, std::vector<std::pair<NodeID, unsigned> > & ResultingNodes);
         void computeReachableNodesWithin(const Node &s, unsigned maxDistance, std::vector<std::pair<NodeID, unsigned> > & ResultingNodes, unsigned threadID);
-        void createPOIIndexArray(unsigned numberOfPOICategories, unsigned _maxDistanceToConsider, unsigned _maxNumberOfPOIsInBucket);
-        void createPOIIndex(unsigned categoryNum, unsigned _maxDistanceToConsider, unsigned _maxNumberOfPOIsInBucket);
-        void addPOIToIndex(unsigned category, NodeID node);
-        void getNearest(unsigned category, NodeID node, std::vector<BucketEntry>& resultingVenues);
-        void getNearest(unsigned category, NodeID node, std::vector<BucketEntry>& resultingVenues, unsigned threadID);
-        void getNearestWithUpperBoundOnLocations(unsigned category, NodeID node, EdgeWeight maxLocations, std::vector<BucketEntry>& resultingVenues);
-        void getNearestWithUpperBoundOnLocations(unsigned category, NodeID node, EdgeWeight maxLocations, std::vector<BucketEntry>& resultingVenues, unsigned threadID);
-        void getNearestWithUpperBoundOnDistance(unsigned category, NodeID node, unsigned maxLocations, std::vector<BucketEntry>& resultingVenues);
-        void getNearestWithUpperBoundOnDistance(unsigned category, NodeID node, unsigned maxLocations, std::vector<BucketEntry>& resultingVenues, unsigned threadID);
-        void getNearestWithUpperBoundOnDistanceAndLocations(unsigned category, NodeID node, EdgeWeight maxDistance, unsigned maxLocations, std::vector<BucketEntry>& resultingVenues);
 
-        void getNearestWithUpperBoundOnDistanceAndLocations(unsigned category, NodeID node, EdgeWeight maxDistance, unsigned maxLocations, std::vector<BucketEntry>& resultingVenues, unsigned threadID);
+        void createPOIIndexArray(unsigned numberOfPOICategories, unsigned _maxDistanceToConsider, unsigned _maxNumberOfPOIsInBucket);
+        void createPOIIndex(const POIKeyType &category, unsigned _maxDistanceToConsider, unsigned _maxNumberOfPOIsInBucket);
+        void addPOIToIndex(const POIKeyType &category, NodeID node);
+
+        void getNearest(const POIKeyType &category, NodeID node, std::vector<BucketEntry>& resultingVenues);
+        void getNearest(const POIKeyType &category, NodeID node, std::vector<BucketEntry>& resultingVenues, unsigned threadID);
+        void getNearestWithUpperBoundOnLocations(const POIKeyType &category, NodeID node, EdgeWeight maxLocations,
+                                                 std::vector<BucketEntry>& resultingVenues);
+        void getNearestWithUpperBoundOnLocations(const POIKeyType &category, NodeID node, EdgeWeight maxLocations,
+                                                 std::vector<BucketEntry>& resultingVenues, unsigned threadID);
+        void getNearestWithUpperBoundOnDistance(const POIKeyType &category, NodeID node, unsigned maxLocations,
+                                                std::vector<BucketEntry>& resultingVenues);
+        void getNearestWithUpperBoundOnDistance(const POIKeyType &category, NodeID node, unsigned maxLocations,
+                                                std::vector<BucketEntry>& resultingVenues, unsigned threadID);
+        void getNearestWithUpperBoundOnDistanceAndLocations(const POIKeyType &category, NodeID node,
+                                                            EdgeWeight maxDistance, unsigned maxLocations, std::vector<BucketEntry>& resultingVenues);
+        void getNearestWithUpperBoundOnDistanceAndLocations(const POIKeyType &category, NodeID node,
+                                                            EdgeWeight maxDistance, unsigned maxLocations,
+                                                            std::vector<BucketEntry>& resultingVenues, unsigned threadID);
 
 	private:
 		unsigned numberOfThreads;
@@ -143,7 +153,7 @@ typedef std::vector<std::pair<NodeID, unsigned> > ReachedNode;
 		QueryGraph * staticGraph;
 		QueryGraph * rangeGraph;
 		vector<SimpleCHQuery<EdgeData, QueryGraph, Heap> *> queryObjects;
-        CHPOIIndexArray poiIndexArray;
+        CHPOIIndexMap poiIndexMap;
 	};
 }
 

--- a/src/cyaccess.pyx
+++ b/src/cyaccess.pyx
@@ -17,8 +17,7 @@ cdef extern from "accessibility.h" namespace "MTC::accessibility":
         Accessibility(int, vector[vector[long]], vector[vector[double]], bool) except +
         vector[string] aggregations
         vector[string] decays
-        void initializePOIs(double, int)
-        void initializeCategory(string, vector[long])
+        void initializeCategory(double, int, string, vector[long])
         pair[vector[vector[double]], vector[vector[int]]] findAllNearestPOIs(
             float, int, string, int)
         void initializeAccVar(string, vector[long], vector[double])
@@ -81,25 +80,22 @@ cdef class cyaccess:
     def __dealloc__(self):
         del self.access
 
-    def initialize_pois(self, maxdist, maxitems):
+    def initialize_category(
+        self,
+        double maxdist,
+        int maxitems,
+        string category,
+        np.ndarray[long] node_ids
+    ):
         """
         maxdist - the maximum distance that will later be used in
             find_all_nearest_pois
         maxitems - the maximum number of items that will later be requested
             in find_all_nearest_pois
-        """
-        self.access.initializePOIs(maxdist, maxitems)
-
-    def initialize_category(
-        self,
-        string category,
-        np.ndarray[long] node_ids
-    ):
-        """
         category - the category name
         node_ids - an array of nodeids which are locations where this poi occurs
         """
-        self.access.initializeCategory(category, node_ids)
+        self.access.initializeCategory(maxdist, maxitems, category, node_ids)
 
     def find_all_nearest_pois(
         self,

--- a/src/cyaccess.pyx
+++ b/src/cyaccess.pyx
@@ -18,9 +18,9 @@ cdef extern from "accessibility.h" namespace "MTC::accessibility":
         vector[string] aggregations
         vector[string] decays
         void initializePOIs(int, double, int)
-        void initializeCategory(int, vector[long])
+        void initializeCategory(string, vector[long])
         pair[vector[vector[double]], vector[vector[int]]] findAllNearestPOIs(
-            float, int, int, int)
+            float, int, string, int)
         void initializeAccVar(string, vector[long], vector[double])
         vector[double] getAllAggregateAccessibilityVariables(
             float, string, string, string, int)
@@ -93,11 +93,11 @@ cdef class cyaccess:
 
     def initialize_category(
         self,
-        int category,
+        string category,
         np.ndarray[long] node_ids
     ):
         """
-        category - the category number
+        category - the category name
         node_ids - an array of nodeids which are locations where this poi occurs
         """
         self.access.initializeCategory(category, node_ids)
@@ -106,13 +106,13 @@ cdef class cyaccess:
         self,
         double radius,
         int num_of_pois,
-        int category,
+        string category,
         int impno=0
     ):
         """
         radius - search radius
         num_of_pois - number of pois to search for
-        category - category id
+        category - the category name
         impno - the impedance id to use
         return_nodeids - whether to return the nodeid locations of the nearest
             not just the distances
@@ -124,12 +124,12 @@ cdef class cyaccess:
 
     def initialize_access_var(
         self,
-        category,
+        string category,
         np.ndarray[long] node_ids,
         np.ndarray[double] values
     ):
         """
-        category - category id
+        category - category name
         node_ids: vector of node identifiers
         values: vector of values that are location at the nodes
         """
@@ -151,7 +151,7 @@ cdef class cyaccess:
     ):
         """
         radius - search radius
-        category - category id
+        category - category name
         aggtyp - aggregation type, see docs
         decay - decay type, see docs
         impno - the impedance id to use

--- a/src/cyaccess.pyx
+++ b/src/cyaccess.pyx
@@ -17,7 +17,7 @@ cdef extern from "accessibility.h" namespace "MTC::accessibility":
         Accessibility(int, vector[vector[long]], vector[vector[double]], bool) except +
         vector[string] aggregations
         vector[string] decays
-        void initializePOIs(int, double, int)
+        void initializePOIs(double, int)
         void initializeCategory(string, vector[long])
         pair[vector[vector[double]], vector[vector[int]]] findAllNearestPOIs(
             float, int, string, int)
@@ -81,15 +81,14 @@ cdef class cyaccess:
     def __dealloc__(self):
         del self.access
 
-    def initialize_pois(self, numcategories, maxdist, maxitems):
+    def initialize_pois(self, maxdist, maxitems):
         """
-        numcategories - number of categories to initialize
         maxdist - the maximum distance that will later be used in
             find_all_nearest_pois
         maxitems - the maximum number of items that will later be requested
             in find_all_nearest_pois
         """
-        self.access.initializePOIs(numcategories, maxdist, maxitems)
+        self.access.initializePOIs(maxdist, maxitems)
 
     def initialize_category(
         self,

--- a/src/graphalg.cpp
+++ b/src/graphalg.cpp
@@ -86,7 +86,7 @@ void Graphalg::Range(int src, double maxdist, int threadNum,
 
 
 DistanceMap
-Graphalg::NearestPOI(int category, int src, double maxdist, int number,
+Graphalg::NearestPOI(const POIKeyType &category, int src, double maxdist, int number,
                      int threadNum) {
     DistanceMap dm;
 

--- a/src/graphalg.h
+++ b/src/graphalg.h
@@ -32,21 +32,20 @@ class Graphalg {
     void Range(int src, double maxdist, int threadNum,
                DistanceVec &ResultingNodes);
 
-    DistanceMap NearestPOI(
-        int category, int src, double maxdist,
-        int number, int threadNum = 0);
+    DistanceMap NearestPOI(const POIKeyType &category, int src, double maxdist,
+                           int number, int threadNum = 0);
 
     void initPOIs(int numcategories, double maxdist, int maxitems) {
         ch.createPOIIndexArray(numcategories, maxdist*DISTANCEMULTFACT,
                                maxitems);
     }
 
-    void addPOIToIndex(int category, int i) {
+    void addPOIToIndex(const POIKeyType &category, int i) {
         ch.addPOIToIndex(category, i);
     }
 
-    void initPOIIndex(int categoryNum, double maxdist, int maxitems) {
-        ch.createPOIIndex(categoryNum, maxdist*DISTANCEMULTFACT, maxitems);
+    void initPOIIndex(const POIKeyType &category, double maxdist, int maxitems) {
+        ch.createPOIIndex(category, maxdist*DISTANCEMULTFACT, maxitems);
     }
 
     int numnodes;

--- a/src/graphalg.h
+++ b/src/graphalg.h
@@ -35,11 +35,6 @@ class Graphalg {
     DistanceMap NearestPOI(const POIKeyType &category, int src, double maxdist,
                            int number, int threadNum = 0);
 
-    void initPOIs(int numcategories, double maxdist, int maxitems) {
-        ch.createPOIIndexArray(numcategories, maxdist*DISTANCEMULTFACT,
-                               maxitems);
-    }
-
     void addPOIToIndex(const POIKeyType &category, int i) {
         ch.addPOIToIndex(category, i);
     }


### PR DESCRIPTION
This PR removes the need to create an initial set of POIIndex entries.

To achieve that, the POIIndex data structure was converted to a `std::map` with `std::string` keys.

The `init_pois` function is still in place because it's also used to define the max_dist and max_pois parameters. We should decide soon if we want to move those definitions to another method.