### PR TITLE
Automatically cast node values to float

### DIFF
--- a/pandana/network.py
+++ b/pandana/network.py
@@ -239,7 +239,7 @@ class Network:
 
         self.net.initialize_access_var(name.encode('utf-8'),
                                        df.node_idx.values.astype('int'),
-                                       df[name].astype('float32').values)
+                                       df[name].values.astype('double'))
 
     def precompute(self, distance):
         """

--- a/pandana/network.py
+++ b/pandana/network.py
@@ -35,7 +35,7 @@ class Network:
     edge_to : Pandas Series, int
         Defines the node id that ends an edge - should refer to the index
         of the two series objects above
-    edge_weights : Pandas DataFrame, all floats
+    edge_weights : Pandas DataFrame, all numerics
         Specifies one or more *impedances* on the network which define the
         distances between nodes.  Multiple impedances can be used to
         capture travel times at different times of day, for instance
@@ -195,7 +195,7 @@ class Network:
         node_ids : Pandas Series, int
             A series of node_ids which are usually computed using
             get_node_ids on this object.
-        variable : Pandas Series, float, optional
+        variable : Pandas Series, numeric, optional
             A series which represents some variable defined in urban space.
             It could be the location of buildings, or the income of all
             households - just about anything can be aggregated using the

--- a/pandana/network.py
+++ b/pandana/network.py
@@ -239,7 +239,7 @@ class Network:
 
         self.net.initialize_access_var(name.encode('utf-8'),
                                        df.node_idx.values.astype('int'),
-                                       df[name].values)
+                                       df[name].astype('float32'))
 
     def precompute(self, distance):
         """

--- a/pandana/network.py
+++ b/pandana/network.py
@@ -239,7 +239,7 @@ class Network:
 
         self.net.initialize_access_var(name.encode('utf-8'),
                                        df.node_idx.values.astype('int'),
-                                       df[name].astype('float32'))
+                                       df[name].astype('float32').values)
 
     def precompute(self, distance):
         """

--- a/pandana/tests/test_pandana.py
+++ b/pandana/tests/test_pandana.py
@@ -195,6 +195,22 @@ def test_agg_variables(sample_osm):
                     assert s.describe()['std'] == 0
 
 
+def test_non_float_node_values(sample_osm):
+    net = sample_osm
+
+    ssize = 50
+    net.set(random_node_ids(sample_osm, ssize),
+            variable=(random_data(ssize)*100).astype('int'))
+
+    for type in net.aggregations:
+        for decay in net.decays:
+            for distance in [5, 10, 20]:
+                t = type.decode(encoding='UTF-8')
+                d = decay.decode(encoding='UTF-8')
+                s = net.aggregate(distance, type=t, decay=d)
+                assert s.describe()['std'] > 0
+
+
 def test_missing_nodeid(sample_osm):
     node_ids = random_node_ids(sample_osm, 50)
     # non-existing value


### PR DESCRIPTION
Related to #105 the `df[name]` column passed to `initialize_access_var` is forced to be float type because currently, Pandana can only perform an accessibility calculation on a network using a table where the variable being aggregated is type Float. 