### PR TITLE
Status messages and compilation settings

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -106,7 +106,7 @@ on your platform - for instance :code:`g++-mp-4.9` or :code:`g++-4.8`.
 
 .. _Anaconda: http://docs.continuum.io/anaconda/
 .. _pip: https://pip.pypa.io/en/latest/
-.. _OpenMP: http://openmp.org/wp/
+.. _OpenMP: http://openmp.org/
 .. _GNU GCC: https://gcc.gnu.org/
 .. _Homebrew: http://brew.sh/
 .. _MacPorts: https://www.macports.org/

--- a/pandana/network.py
+++ b/pandana/network.py
@@ -79,16 +79,16 @@ class Network:
                           self._node_indexes(edges_df["to"])], axis=1)
 
         self.net = cyaccess(self.node_idx.values,
-                            nodes_df.astype('double').as_matrix(),
-                            edges.as_matrix(),
+                            nodes_df.astype('double').values,
+                            edges.values,
                             edges_df[edge_weights.columns].transpose()
                                                           .astype('double')
-                                                          .as_matrix(),
+                                                          .values,
                             twoway)
 
         self._twoway = twoway
 
-        self.kdtree = KDTree(nodes_df.as_matrix())
+        self.kdtree = KDTree(nodes_df.values)
 
     @classmethod
     def from_hdf5(cls, filename):
@@ -368,7 +368,7 @@ class Network:
         """
         xys = pd.DataFrame({'x': x_col, 'y': y_col})
 
-        distances, indexes = self.kdtree.query(xys.as_matrix())
+        distances, indexes = self.kdtree.query(xys.values)
         indexes = np.transpose(indexes)[0]
         distances = np.transpose(distances)[0]
 

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,10 @@ from setuptools.command.test import test as TestCommand
 from setuptools.command.build_ext import build_ext
 
 
+###############################################
+## Invoking tests
+###############################################
+
 class PyTest(TestCommand):
     user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]
 
@@ -46,9 +50,12 @@ class CustomBuildExtCommand(build_ext):
         build_ext.run(self)
 
 
-packages = find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"])
+###############################################
+## Building the C++ extension
+###############################################
 
-extra_compile_args = ['-w', '-std=c++0x', '-O3', '-fpic', '-g']
+extra_compile_args = ['-w', '-std=c++11']
+# extra_compile_args = ['-w', '-std=c++0x', '-O3', '-fpic', '-g']
 extra_link_args = []
 
 # Mac compiler arguments, may not work pre MacOS 10.9
@@ -65,7 +72,26 @@ elif os.environ.get('USEOPENMP') or not sys.platform.startswith('darwin'):
     extra_compile_args += ['-fopenmp']
     extra_link_args += ['-lgomp']
 
+cyaccess = Extension(
+        name='pandana.cyaccess',
+        sources=[
+            'src/accessibility.cpp',
+            'src/graphalg.cpp',
+            'src/cyaccess.pyx',
+            'src/contraction_hierarchies/src/libch.cpp'],
+        language='c++',
+        include_dirs=['.'],
+        extra_compile_args=extra_compile_args,
+        extra_link_args=extra_link_args)
+
+
+###############################################
+## Standard setup
+###############################################
+
 version = '0.4.1'
+
+packages = find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"])
 
 # read long description from README
 with open('README.rst', 'r') as f:
@@ -81,18 +107,7 @@ setup(
                  'dataframes of network queries, quickly'),
     long_description=long_description,
     url='https://udst.github.io/pandana/',
-    ext_modules=[Extension(
-            name='pandana.cyaccess',
-            sources=[
-                'src/accessibility.cpp',
-                'src/graphalg.cpp',
-                'src/cyaccess.pyx',
-                'src/contraction_hierarchies/src/libch.cpp'],
-            language='c++',
-            include_dirs=['.'],
-            extra_compile_args=extra_compile_args,
-            extra_link_args=extra_link_args,
-        )],
+    ext_modules=[cyaccess],
     install_requires=[
         'matplotlib>=1.3.1',
         'numpy>=1.8.0',

--- a/setup.py
+++ b/setup.py
@@ -58,19 +58,20 @@ extra_compile_args = ['-w', '-std=c++11']
 # extra_compile_args = ['-w', '-std=c++0x', '-O3', '-fpic', '-g']
 extra_link_args = []
 
-# Mac compiler arguments, may not work pre MacOS 10.9
-if sys.platform.startswith('darwin'):
+if sys.platform.startswith('darwin'):  # OS X, should work in 10.9+
     extra_compile_args += ['-D NO_TR1_MEMORY', '-stdlib=libc++']
     extra_link_args += ['-stdlib=libc++']
+    
+    if os.environ.get('USEOPENMP'):
+        extra_compile_args += ['-fopenmp']
 
-# Windows compiler arguments
-if sys.platform.startswith('win'):
+elif sys.platform.startswith('win'):  # Windows
     extra_compile_args = ['/w', '/openmp']
 
-# Use OpenMP on Linux, and on Mac if directed
-elif os.environ.get('USEOPENMP') or not sys.platform.startswith('darwin'):
+else:  # Linux
     extra_compile_args += ['-fopenmp']
     extra_link_args += ['-lgomp']
+
 
 cyaccess = Extension(
         name='pandana.cyaccess',

--- a/setup.py
+++ b/setup.py
@@ -46,35 +46,17 @@ class CustomBuildExtCommand(build_ext):
         build_ext.run(self)
 
 
-include_dirs = [
-    '.'
-]
-
 packages = find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"])
 
-source_files = [
-    'src/accessibility.cpp',
-    'src/graphalg.cpp',
-    "src/cyaccess.pyx",
-    'src/contraction_hierarchies/src/libch.cpp'
-]
-
-extra_compile_args = [
-    '-w',
-    '-std=c++0x',
-    '-O3',
-    '-fpic',
-    '-g',
-]
-
+extra_compile_args = ['-w', '-std=c++0x', '-O3', '-fpic', '-g']
 extra_link_args = []
 
-# Mac compiler options, may not work pre MacOS 10.9
+# Mac compiler arguments, may not work pre MacOS 10.9
 if sys.platform.startswith('darwin'):
     extra_compile_args += ['-D NO_TR1_MEMORY', '-stdlib=libc++']
     extra_link_args += ['-stdlib=libc++']
 
-# Windows compiler options
+# Windows compiler arguments
 if sys.platform.startswith('win'):
     extra_compile_args = ['/w', '/openmp']
 
@@ -100,10 +82,14 @@ setup(
     long_description=long_description,
     url='https://udst.github.io/pandana/',
     ext_modules=[Extension(
-            'pandana.cyaccess',
-            source_files,
-            language="c++",
-            include_dirs=include_dirs,
+            name='pandana.cyaccess',
+            sources=[
+                'src/accessibility.cpp',
+                'src/graphalg.cpp',
+                'src/cyaccess.pyx',
+                'src/contraction_hierarchies/src/libch.cpp'],
+            language='c++',
+            include_dirs=['.'],
             extra_compile_args=extra_compile_args,
             extra_link_args=extra_link_args,
         )],
@@ -127,6 +113,7 @@ setup(
         'Development Status :: 3 - Alpha',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'License :: OSI Approved :: GNU Affero General Public License v3'
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -38,8 +38,8 @@ class PyTest(TestCommand):
 class Lint(TestCommand):
     def run(self):
         os.system("cpplint --filter=-build/include_subdir,-legal/copyright,-runtime/references,-runtime/int src/accessibility.* src/graphalg.*")
-        os.system("pep8 src/cyaccess.pyx")
-        os.system("pep8 pandana")
+        os.system("pycodestyle src/cyaccess.pyx")
+        os.system("pycodestyle pandana")
 
 
 ###############################################
@@ -110,7 +110,10 @@ setup(
         'cython>=0.25.2',
         'scikit-learn>=0.18.1'
     ],
-    tests_require=['pytest'],
+    tests_require=[
+        'pycodestyle',
+        'pytest'
+    ],
     cmdclass={
         'test': PyTest,
         'lint': Lint,

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,14 @@ class Lint(TestCommand):
         os.system("pycodestyle pandana")
 
 
+class CustomBuildExtCommand(build_ext):
+    """build_ext command for use when numpy headers are needed."""
+    def run(self):
+        import numpy as np
+        self.include_dirs.append(np.get_include())
+        build_ext.run(self)
+
+
 ###############################################
 ## Building the C++ extension
 ###############################################
@@ -117,6 +125,7 @@ setup(
     cmdclass={
         'test': PyTest,
         'lint': Lint,
+        'build_ext': CustomBuildExtCommand,
     },
     classifiers=[
         'Development Status :: 3 - Alpha',

--- a/setup.py
+++ b/setup.py
@@ -57,11 +57,14 @@ class CustomBuildExtCommand(build_ext):
 extra_compile_args = ['-w', '-std=c++11', '-O3']
 extra_link_args = []
 
+# Mac compilation: flags are for the llvm compilers included with recent
+# versions of Xcode Command Line Tools, or newer versions installed separately
+
 if sys.platform.startswith('darwin'):  # Mac
     
     # This environment variable sets the earliest OS version that the compiled
     # code will be compatible with. In certain contexts the default is too old
-    # to allow using libc++; supporting 10.9 and later seems safe
+    # to allow using libc++; supporting OS X 10.9 and later seems safe
     os.environ['MACOSX_DEPLOYMENT_TARGET'] = '10.9'
     
     extra_compile_args += ['-D NO_TR1_MEMORY', '-stdlib=libc++']
@@ -70,8 +73,12 @@ if sys.platform.startswith('darwin'):  # Mac
     if os.environ.get('USEOPENMP'):
         extra_compile_args += ['-fopenmp']
 
+# Window compilation: flags are for Visual C++
+
 elif sys.platform.startswith('win'):  # Windows
     extra_compile_args = ['/w', '/openmp']
+
+# Linux compilation: flags are for gcc 4.8 and later
 
 else:  # Linux
     extra_compile_args += ['-fopenmp']

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,13 @@ class CustomBuildExtCommand(build_ext):
 extra_compile_args = ['-w', '-std=c++11', '-O3']
 extra_link_args = []
 
-if sys.platform.startswith('darwin'):  # OS X, should work in 10.9+
+if sys.platform.startswith('darwin'):  # Mac
+    
+    # This environment variable sets the earliest OS version that the compiled
+    # code will be compatible with. In certain contexts the default is too old
+    # to allow using libc++; supporting 10.9 and later seems safe
+    os.environ['MACOSX_DEPLOYMENT_TARGET'] = '10.9'
+    
     extra_compile_args += ['-D NO_TR1_MEMORY', '-stdlib=libc++']
     extra_link_args += ['-stdlib=libc++']
     

--- a/setup.py
+++ b/setup.py
@@ -42,14 +42,6 @@ class Lint(TestCommand):
         os.system("pep8 pandana")
 
 
-class CustomBuildExtCommand(build_ext):
-    """build_ext command for use when numpy headers are needed."""
-    def run(self):
-        import numpy as np
-        self.include_dirs.append(np.get_include())
-        build_ext.run(self)
-
-
 ###############################################
 ## Building the C++ extension
 ###############################################
@@ -122,7 +114,6 @@ setup(
     cmdclass={
         'test': PyTest,
         'lint': Lint,
-        'build_ext': CustomBuildExtCommand,
     },
     classifiers=[
         'Development Status :: 3 - Alpha',

--- a/setup.py
+++ b/setup.py
@@ -66,30 +66,22 @@ extra_compile_args = [
     '-fpic',
     '-g',
 ]
-extra_link_args = None
 
-# separate compiler options for Windows
+extra_link_args = []
+
+# Mac compiler options, may not work pre MacOS 10.9
+if sys.platform.startswith('darwin'):
+    extra_compile_args += ['-D NO_TR1_MEMORY', '-stdlib=libc++']
+    extra_link_args += ['-stdlib=libc++']
+
+# Windows compiler options
 if sys.platform.startswith('win'):
     extra_compile_args = ['/w', '/openmp']
-# Use OpenMP if directed or not on a Mac
+
+# Use OpenMP on Linux, and on Mac if directed
 elif os.environ.get('USEOPENMP') or not sys.platform.startswith('darwin'):
     extra_compile_args += ['-fopenmp']
-    extra_link_args = [
-        '-lgomp'
-    ]
-
-# recent versions of the OS X SDK don't have the tr1 namespace
-# and we need to flag that during compilation.
-# here we need to check what version of OS X is being targeted
-# for the installation.
-# this is potentially different than the version of OS X on the system.
-if platform.system() == 'Darwin':
-    mac_ver = sysconfig.get_config_var('MACOSX_DEPLOYMENT_TARGET')
-    if mac_ver:
-        mac_ver = [int(x) for x in mac_ver.split('.')]
-        if mac_ver >= [10, 7]:
-            extra_compile_args += ['-D NO_TR1_MEMORY']
-            extra_compile_args += ['-stdlib=libc++']
+    extra_link_args += ['-lgomp']
 
 version = '0.4.1'
 

--- a/setup.py
+++ b/setup.py
@@ -54,8 +54,7 @@ class CustomBuildExtCommand(build_ext):
 ## Building the C++ extension
 ###############################################
 
-extra_compile_args = ['-w', '-std=c++11']
-# extra_compile_args = ['-w', '-std=c++0x', '-O3', '-fpic', '-g']
+extra_compile_args = ['-w', '-std=c++11', '-O3']
 extra_link_args = []
 
 if sys.platform.startswith('darwin'):  # OS X, should work in 10.9+

--- a/src/contraction_hierarchies/src/DataStructures/Percent.h
+++ b/src/contraction_hierarchies/src/DataStructures/Percent.h
@@ -54,8 +54,8 @@ public:
             _nextThreshold += _intervalPercent;
             printPercent( currentValue / (double)_maxValue * 100 );
         }
-        // if (currentValue + 1 == _maxValue)
-            // std::cout << " 100%" << std::endl;
+        if (currentValue + 1 == _maxValue)
+            std::cout << " 100%" << std::endl;
     }
 
     void printIncrement()
@@ -77,12 +77,12 @@ private:
         while (percent >= _lastPercent+_step) {
             _lastPercent+=_step;
             if (_lastPercent % 10 == 0) {
-                // std::cout << " " << _lastPercent << "% ";
+                std::cout << " " << _lastPercent << "% ";
             }
             else {
-                // std::cout << ".";
+                std::cout << ".";
             }
-            // std::cout.flush();
+            std::cout.flush();
         }
     }
 };

--- a/src/contraction_hierarchies/src/libch.cpp
+++ b/src/contraction_hierarchies/src/libch.cpp
@@ -202,6 +202,10 @@ inline ostream& operator<< (ostream& os, const Edge& e) {
                 }
             }
         }
+        
+        FILE_LOG(logINFO) << "Range graph removed " << edges.size() - edge 
+                          << " edges of " << edges.size() << "\n";
+        
         //INFO("Range graph removed " << edges.size() - edge << " edges of " << edges.size());
         assert(edge <= edges.size());
         edges.resize( edge );

--- a/src/contraction_hierarchies/src/libch.h
+++ b/src/contraction_hierarchies/src/libch.h
@@ -34,6 +34,8 @@ or see http://www.gnu.org/licenses/agpl.txt.
 #include "DataStructures/StaticGraph.h"
 #include "POIIndex/POIIndex.h"
 
+#define FILE_LOG(logINFO) (std::cout)
+
 struct _HeapData {
     NodeID parent;
     _HeapData( NodeID p ) : parent(p) { }

--- a/src/graphalg.cpp
+++ b/src/graphalg.cpp
@@ -9,6 +9,10 @@ Graphalg::Graphalg(
     this->numnodes = numnodes;
 
     int num = omp_get_max_threads();
+    
+    FILE_LOG(logINFO) << "Generating contraction hierarchies with "
+                      << num << " threads.\n";
+    
     ch = CH::ContractionHierarchies(num);
 
     vector<CH::Node> nv;
@@ -20,7 +24,10 @@ Graphalg::Graphalg(
         nv.push_back(n);
     }
 
-    ch.SetNodeVector(nv);
+    FILE_LOG(logINFO) << "Setting CH node vector of size "
+				      << nv.size() << "\n";
+	
+	ch.SetNodeVector(nv);
 
     vector<CH::Edge> ev;
 
@@ -30,6 +37,9 @@ Graphalg::Graphalg(
         ev.push_back(e);
     }
 
+    FILE_LOG(logINFO) << "Setting CH edge vector of size "
+				      << ev.size() << "\n";
+    
     ch.SetEdgeVector(ev);
     ch.RunPreprocessing();
 }

--- a/src/graphalg.cpp
+++ b/src/graphalg.cpp
@@ -37,7 +37,7 @@ Graphalg::Graphalg(
         ev.push_back(e);
     }
 
-    FILE_LOG(logINFO) << "Setting CH edge vector of size x"
+    FILE_LOG(logINFO) << "Setting CH edge vector of size "
                       << ev.size() << "\n";
     
     ch.SetEdgeVector(ev);

--- a/src/graphalg.cpp
+++ b/src/graphalg.cpp
@@ -25,7 +25,7 @@ Graphalg::Graphalg(
     }
 
     FILE_LOG(logINFO) << "Setting CH node vector of size "
-				      << nv.size() << "\n";
+                      << nv.size() << "\n";
 	
     ch.SetNodeVector(nv);
 
@@ -38,7 +38,7 @@ Graphalg::Graphalg(
     }
 
     FILE_LOG(logINFO) << "Setting CH edge vector of size x"
-				      << ev.size() << "\n";
+                      << ev.size() << "\n";
     
     ch.SetEdgeVector(ev);
     ch.RunPreprocessing();

--- a/src/graphalg.cpp
+++ b/src/graphalg.cpp
@@ -27,7 +27,7 @@ Graphalg::Graphalg(
     FILE_LOG(logINFO) << "Setting CH node vector of size "
 				      << nv.size() << "\n";
 	
-	ch.SetNodeVector(nv);
+    ch.SetNodeVector(nv);
 
     vector<CH::Edge> ev;
 
@@ -37,7 +37,7 @@ Graphalg::Graphalg(
         ev.push_back(e);
     }
 
-    FILE_LOG(logINFO) << "Setting CH edge vector of size "
+    FILE_LOG(logINFO) << "Setting CH edge vector of size x"
 				      << ev.size() << "\n";
     
     ch.SetEdgeVector(ev);

--- a/src/shared.h
+++ b/src/shared.h
@@ -9,3 +9,4 @@
 #ifdef _OPENMP
 #include <omp.h>
 #endif
+#define FILE_LOG(logINFO) (std::cout)


### PR DESCRIPTION
This PR includes a few pieces of maintenance that I'm working on in parallel:

### 1. Updates the compilation settings in `setup.py`

Recent versions of OS X weren't able to install Pandana from source because of outdated compiler settings. I think i've fixed it. This procedure is working on multiple machines:

- check that you have Xcode command line tools installed: `xcode-select --install`
- set up a clean Python environment (i've been using conda and python 3.6)
- install numpy and cython, which are required to build the C++ extension
- `python setup.py develop`

For multi-threaded installation, see [comment](https://github.com/UDST/pandana/pull/109#issuecomment-485021324) below (and issue #104).

### 2. Restores contraction hierarchy status messages from Pandana 0.3

Pandana used to print status messages when you built a network:

```
Generating contraction hierarchies with 1 threads.
Setting CH node vector of size 1498
Setting CH edge vector of size 1702
Range graph removed 1900 edges of 3404
. 10% . 20% . 30% . 40% . 50% . 60% . 70% . 80% . 90% . 100%
```

These were removed in Pandana 0.4:
https://github.com/UDST/pandana/commit/989efcc8e6c4206b02bfbd986eac8075a08ed75c#diff-b5456dd6223748303b0929471b1231ed
https://github.com/UDST/pandana/commit/6544efbbfc47bd81919ef4b7254ac035107d10fe#diff-47d7b75a6b197df3c859e0497e0b3e2c

But i think they're useful, so this PR adds them back. This restores the thread count diagnostic message requested in issue #104.

### 3. Resolves some deprecation warnings

Per issue #103, this PR updates `network.py` to use `.values` instead of `.as_matrix()`.

### To do before merging:

- [x] add more environments to the Travis build, or manually test installation in mac, win, py27
- [x] get reviews from folks more familiar with the C++ code