### PR TITLE
Optimized std::string comparisons

### DIFF
--- a/src/accessibility.cpp
+++ b/src/accessibility.cpp
@@ -349,6 +349,18 @@ Accessibility::aggregateAccessibilityVariable(
     double sum = 0.0;
     double sumsq = 0.0;
 
+    std::function<double(const double &, const float &, const float &)> sum_function;
+
+    if(decay == "exp")
+        sum_function = [](const double &distance, const float &radius, const float &var)
+                       { return exp(-1*distance/radius) * var; };
+    if(decay == "linear")
+    	sum_function = [](const double &distance, const float &radius, const float &var)
+                       { return (1.0-distance/radius) * var; };
+    if(decay == "flat")
+        sum_function = [](const double &distance, const float &radius, const float &var)
+                       { return var; };
+
     for (int i = 0 ; i < distances.size() ; i++) {
         int nodeid = distances[i].first;
         double distance = distances[i].second;
@@ -358,19 +370,7 @@ Accessibility::aggregateAccessibilityVariable(
 
         for (int j = 0 ; j < vars[nodeid].size() ; j++) {
             cnt++;  // count items
-
-            if (decay == "exp") {
-                sum += exp(-1*distance/radius) * vars[nodeid][j];
-
-            } else if (decay == "linear") {
-                sum += (1.0-distance/radius) * vars[nodeid][j];
-
-            } else if (decay == "flat") {
-                sum += vars[nodeid][j];
-
-            } else {
-                assert(0);
-            }
+            sum += sum_function(distance, radius, vars[nodeid][j]);
 
             // stddev is always flat
             sumsq += vars[nodeid][j] * vars[nodeid][j];


### PR DESCRIPTION
Part of the modifications from 0.3 to 0.4 included modifying the `decay` parameter from an `enum` to `std::string`. That is a good modification in terms of functionality but it seems to be that it made the library slower.

In this PR the comparisons are avoided by choosing a decay function before executing the loops. In my local environment, the performance improved (for the SEMCOG example) and it's very similar to `v0.3`.