### PR TITLE
Fixing Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: python
 sudo: false
 python:
 - '2.7'
-- '3.5'
+- '3.6'
+- '3.7'
 addons:
   apt:
     sources:
@@ -22,7 +23,7 @@ install:
 - conda update -q conda
 - conda info -a
 - |
-  conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION basemap matplotlib numpy pandas pip pytables requests cython scikit-learn "pytest<4.0"
+  conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION basemap matplotlib numpy pandas pytables requests cython scikit-learn "pytest<4.0"
 - source activate test-environment
 - pip install pytest-cov coveralls pycodestyle osmnet
 - CC=gcc-4.9 CXX=g++-4.9 python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 python:
 - '2.7'
 - '3.6'
-- '3.7'
 addons:
   apt:
     sources:


### PR DESCRIPTION
This PR fixes the Travis builds.

### Description

It seems like a problem emerged in the last few months, related to including pip in the conda environment. Example of a failed build: https://travis-ci.org/UDST/pandana/builds/557649396

There's actually no need to install pip like that; it's there automatically. This PR removes it from the script, and the builds work again.

I also switched the Python 3 environment from 3.5 to 3.6, which is the current stable release.

### Should we do some additional Travis cleanup?

I would be in favor of overhauling the Travis script so that it builds Pandana from source the same way users will -- something like `pip install .`, without using conda at all. 

This seems like a better test of the build process and requirements list than the current script, and it would run faster too. Should i try this out? 

Here's an example of a much cleaner Travis script: https://github.com/UDST/choicemodels/blob/master/.travis.yml