### PR TITLE
Travis cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,15 @@ language: python
 
 python:
   - '2.7'
+  - '3.5'
   - '3.6'
+
+# This section can be removed when Python 3.7 is more cleanly supported in Travis
+matrix:
+  include:
+    - python: '3.7'
+      dist: xenial
+      sudo: true
 
 install:
   - pip install .
@@ -16,39 +24,8 @@ script:
 
 after_success:
   - coveralls
+  - bin/build_docs.sh
 
-#addons:
-#  apt:
-#    sources:
-#      - ubuntu-toolchain-r-test
-#    packages:
-#      - g++-4.9
-#install:
-#- if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-#    wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
-#  else
-#    wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-#  fi
-#- bash miniconda.sh -b -p $HOME/miniconda
-#- export PATH="$HOME/miniconda/bin:$PATH"
-#- hash -r
-#- conda config --set always_yes yes --set changeps1 no
-#- conda update -q conda
-#- conda info -a
-#- |
-#  conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION basemap matplotlib numpy pandas pytables requests cython scikit-learn "pytest<4.0"
-#- source activate test-environment
-#- pip install pytest-cov coveralls pycodestyle osmnet
-#- CC=gcc-4.9 CXX=g++-4.9 python setup.py install
-#script:
-#- pycodestyle pandana
-#- python setup.py test --pytest-args "--cov pandana --cov-report term-missing"
-#after_success:
-#- coveralls
-#- bin/build_docs.sh
-#notifications:
-#  slack:
-#    secure: a6RjANmfIyE0s3iAz4LPy2wS0bOd+ijGlhh7CJf4bRwVnQPuihDTwzQiT92Uje1rHZVUTY0r5A7QzBcg7QcACs/b3hLQ6nYQ0kIm/beC5DfZUqlyHQAuRl6eK76cEg9Le7bX8OXrjWyfTs9jgH7Z2mRGutMieNXVYQG5wMlEKlU=
-#env:
-#  global:
-#    secure: CMG0rjBgDBNy5FdfXawaaCCJm9ChzHk7e21ywVhIc1jbVS6lMn6bqwKJUnLaJAyjDhhZuxXTcHy+SALJgbzqLrH4GM5hOOL+8Rf4Jf9ESZzTBryvypRecVnUnk63SpJiq2Ki8maNrOcK1IBUAoFhFzptSgE4MDkxZ0LjsDAums8=
+env:
+  global:
+    secure: CMG0rjBgDBNy5FdfXawaaCCJm9ChzHk7e21ywVhIc1jbVS6lMn6bqwKJUnLaJAyjDhhZuxXTcHy+SALJgbzqLrH4GM5hOOL+8Rf4Jf9ESZzTBryvypRecVnUnk63SpJiq2Ki8maNrOcK1IBUAoFhFzptSgE4MDkxZ0LjsDAums8=

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,40 +1,54 @@
 language: python
-sudo: false
+
 python:
-- '2.7'
-- '3.6'
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-    packages:
-      - g++-4.9
+  - '2.7'
+  - '3.6'
+
 install:
-- if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-    wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
-  else
-    wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-  fi
-- bash miniconda.sh -b -p $HOME/miniconda
-- export PATH="$HOME/miniconda/bin:$PATH"
-- hash -r
-- conda config --set always_yes yes --set changeps1 no
-- conda update -q conda
-- conda info -a
-- |
-  conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION basemap matplotlib numpy pandas pytables requests cython scikit-learn "pytest<4.0"
-- source activate test-environment
-- pip install pytest-cov coveralls pycodestyle osmnet
-- CC=gcc-4.9 CXX=g++-4.9 python setup.py install
+  - pip install .
+  - pip install -r requirements-dev.txt
+  - pip list
+  - pip show pandana
+
 script:
-- pycodestyle pandana
-- python setup.py test --pytest-args "--cov pandana --cov-report term-missing"
+  - pycodestyle pandana
+  - python setup.py test --pytest-args "--cov pandana --cov-report term-missing"
+
 after_success:
-- coveralls
-- bin/build_docs.sh
-notifications:
-  slack:
-    secure: a6RjANmfIyE0s3iAz4LPy2wS0bOd+ijGlhh7CJf4bRwVnQPuihDTwzQiT92Uje1rHZVUTY0r5A7QzBcg7QcACs/b3hLQ6nYQ0kIm/beC5DfZUqlyHQAuRl6eK76cEg9Le7bX8OXrjWyfTs9jgH7Z2mRGutMieNXVYQG5wMlEKlU=
-env:
-  global:
-    secure: CMG0rjBgDBNy5FdfXawaaCCJm9ChzHk7e21ywVhIc1jbVS6lMn6bqwKJUnLaJAyjDhhZuxXTcHy+SALJgbzqLrH4GM5hOOL+8Rf4Jf9ESZzTBryvypRecVnUnk63SpJiq2Ki8maNrOcK1IBUAoFhFzptSgE4MDkxZ0LjsDAums8=
+  - coveralls
+
+#addons:
+#  apt:
+#    sources:
+#      - ubuntu-toolchain-r-test
+#    packages:
+#      - g++-4.9
+#install:
+#- if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
+#    wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
+#  else
+#    wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+#  fi
+#- bash miniconda.sh -b -p $HOME/miniconda
+#- export PATH="$HOME/miniconda/bin:$PATH"
+#- hash -r
+#- conda config --set always_yes yes --set changeps1 no
+#- conda update -q conda
+#- conda info -a
+#- |
+#  conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION basemap matplotlib numpy pandas pytables requests cython scikit-learn "pytest<4.0"
+#- source activate test-environment
+#- pip install pytest-cov coveralls pycodestyle osmnet
+#- CC=gcc-4.9 CXX=g++-4.9 python setup.py install
+#script:
+#- pycodestyle pandana
+#- python setup.py test --pytest-args "--cov pandana --cov-report term-missing"
+#after_success:
+#- coveralls
+#- bin/build_docs.sh
+#notifications:
+#  slack:
+#    secure: a6RjANmfIyE0s3iAz4LPy2wS0bOd+ijGlhh7CJf4bRwVnQPuihDTwzQiT92Uje1rHZVUTY0r5A7QzBcg7QcACs/b3hLQ6nYQ0kIm/beC5DfZUqlyHQAuRl6eK76cEg9Le7bX8OXrjWyfTs9jgH7Z2mRGutMieNXVYQG5wMlEKlU=
+#env:
+#  global:
+#    secure: CMG0rjBgDBNy5FdfXawaaCCJm9ChzHk7e21ywVhIc1jbVS6lMn6bqwKJUnLaJAyjDhhZuxXTcHy+SALJgbzqLrH4GM5hOOL+8Rf4Jf9ESZzTBryvypRecVnUnk63SpJiq2Ki8maNrOcK1IBUAoFhFzptSgE4MDkxZ0LjsDAums8=

--- a/bin/build_docs.sh
+++ b/bin/build_docs.sh
@@ -33,9 +33,10 @@ if [ "$TRAVIS_REPO_SLUG" == "UDST/pandana" ] && \
         [ "$TRAVIS_PULL_REQUEST" == "false" ] && \
         [ "$ACTUAL_TRAVIS_JOB_NUMBER" == "1" ]; then
 
-        echo "Installing dependencies"
-        conda install --yes --quiet sphinx numpydoc
-        pip install sphinx_rtd_theme
+        # These are now included in requirements-dev.txt
+        # echo "Installing dependencies"
+        # conda install --yes --quiet sphinx numpydoc
+        # pip install sphinx_rtd_theme
 
         echo "Building docs"
         cd docs

--- a/bin/build_docs.sh
+++ b/bin/build_docs.sh
@@ -33,11 +33,6 @@ if [ "$TRAVIS_REPO_SLUG" == "UDST/pandana" ] && \
         [ "$TRAVIS_PULL_REQUEST" == "false" ] && \
         [ "$ACTUAL_TRAVIS_JOB_NUMBER" == "1" ]; then
 
-        # These are now included in requirements-dev.txt
-        # echo "Installing dependencies"
-        # conda install --yes --quiet sphinx numpydoc
-        # pip install sphinx_rtd_theme
-
         echo "Building docs"
         cd docs
         make clean

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,9 @@
+# requirements for development and testing
+
+coveralls
+numpydoc
+pycodestyle
+pytest < 4.0
+pytest-cov
+sphinx
+sphinx_rtd_theme

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@
 coveralls
 numpydoc
 pycodestyle
-pytest < 4.0
+pytest >= 3.6 < 4.0
 pytest-cov
 sphinx
 sphinx_rtd_theme

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@
 coveralls
 numpydoc
 pycodestyle
-pytest >= 3.6 < 4.0
+pytest>=3.6,<4.0
 pytest-cov
 sphinx
 sphinx_rtd_theme

--- a/setup.py
+++ b/setup.py
@@ -34,8 +34,8 @@ class PyTest(TestCommand):
 class Lint(TestCommand):
     def run(self):
         os.system("cpplint --filter=-build/include_subdir,-legal/copyright,-runtime/references,-runtime/int src/accessibility.* src/graphalg.*")
-        os.system("pep8 src/cyaccess.pyx")
-        os.system("pep8 pandana")
+        os.system("pycodestyle src/cyaccess.pyx")
+        os.system("pycodestyle pandana")
 
 
 class CustomBuildExtCommand(build_ext):

--- a/setup.py
+++ b/setup.py
@@ -132,9 +132,11 @@ setup(
         'build_ext': CustomBuildExtCommand,
     },
     classifiers=[
-        'Development Status :: 3 - Alpha',
+        'Development Status :: 4 - Beta',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'License :: OSI Approved :: GNU Affero General Public License v3'
     ],
 )


### PR DESCRIPTION
This PR updates and simplifies the Travis script, without changing its core behavior. 

1. Travis now runs tests for Python 2.7, 3.5, 3.6, and 3.7

2. I created a `requirements-dev.txt` that lists all packages used for running tests and building docs

3. Travis now installs `pandana` using the standard requirements list and compilation settings -- no more extra packages, conda downloads, or ubuntu add-ons. This had accumulated over the years, but we don't need it

4. Still runs the same linting, tests, coverage reports, and doc building script

5. In `setup.py` i changed the project status from alpha to beta and added Python 3.6 and 3.7 as supported platforms