### PR TITLE
Exposing network.shortest_path_length()

### DIFF
--- a/examples/shortest_path_example.py
+++ b/examples/shortest_path_example.py
@@ -1,0 +1,55 @@
+"""
+This is a simple test of pandana functionality. If it runs with no errors
+you should see output something like:
+
+> python demos/example.py
+Generating contraction hierarchies with 4 threads.
+Setting CH node vector of size 1498
+Setting CH edge vector of size 1702
+[info src/contraction_hierarchies/src/libch.cpp:205] Range graph removed 1900 edges of 3404
+. 10% . 20% . 30% . 40% . 50% . 60% . 70% . 80% . 90% . 100%
+ 100%
+
+Depending on whether your installed copy of pandana was built with OpenMP
+support it may be run with multiple threads or only 1.
+
+"""
+from __future__ import print_function
+
+import os.path
+import sys
+
+import numpy as np
+import pandas as pd
+import pandana.network as pdna
+
+if len(sys.argv) > 1:
+    # allow test file to be passed as an argument
+    storef = sys.argv[1]
+else:
+    # if no argument provided look for it in the test data
+    storef = os.path.normpath(os.path.join(
+        os.path.dirname(os.path.abspath(__file__)),
+        '../pandana/tests/osm_sample.h5'))
+
+if not os.path.isfile(storef):
+    raise IOError('Could not find test input file: {!r}'.format(storef))
+
+print('Building network from file: {!r}'.format(storef))
+
+store = pd.HDFStore(storef, "r")
+nodes, edges = store.nodes, store.edges
+net = pdna.Network(nodes.x, nodes.y, edges["from"], edges.to,
+                   edges[["weight"]])
+store.close()
+print()
+
+# Demonstrate shortest path code
+print('Shortest path from first to last node:')
+a = nodes.index[0]
+print(a)
+b = nodes.index[-1]
+print(b)
+# Note that the 'weight' is 1.0 for each link, so results aren't very interesting
+print(net.shortest_path(a,b))
+print(net.shortest_path_length(a,b,'weight'))

--- a/pandana/network.py
+++ b/pandana/network.py
@@ -228,7 +228,7 @@ class Network:
 
         imp_num = self._imp_name_to_num(imp_name)
 
-        len = self.net.shortest_path_length(node_a, node_b, imp_num)
+        len = self.net.shortest_path_distance(node_a, node_b, imp_num)
 
         return len
 

--- a/pandana/network.py
+++ b/pandana/network.py
@@ -202,6 +202,36 @@ class Network:
         # map back to external node ids
         return self.node_ids.values[path]
 
+    def shortest_path_length(self, node_a, node_b, imp_name):
+        """
+        Return the length of the shortest path between two node ids in the
+        network. Requires an impedance metric.
+
+        Parameters
+        ----------
+        node_a : int
+             The source node label
+        node_b : int
+             The destination node label
+        imp_name : string
+            The impedance name to use for the shortest path
+
+        Returns
+        -------
+        Float
+
+        """
+        # map to internal node indexes
+        node_idx = self._node_indexes(pd.Series([node_a, node_b]))
+        node_a = node_idx.iloc[0]
+        node_b = node_idx.iloc[1]
+
+        imp_num = self._imp_name_to_num(imp_name)
+
+        len = self.net.shortest_path_length(node_a, node_b, imp_num)
+
+        return len
+
     def set(self, node_ids, variable=None, name="tmp"):
         """
         Characterize urban space with a variable that is related to nodes in


### PR DESCRIPTION
This PR exposes some functionality that was previously implemented in the C++ code but left out of the Python API.

Specifically, it adds a `network.shortest_path_length()` function, which returns the impedance-weighted length between two arbitrary nodes on a network. This complements the `network.shortest_path()` function, which provides the list of nodes making up the path.

Performance should be very good, since it takes full advantage of the contraction hierarchies. You can see it in action by running 'examples/shortest_path_example.py'.

Note that the C++ code calls this 'shortest_path_distance', but I've named the Python function 'shortest_path_length' to align with the equivalent NetworkX functionality.

### Testing

@jessicacamacho has been trying out this functionality and it seems to work well. With a long list of OD pairs there's a big performance advantage to running the loop on the C++ side, so we're going to add that in a subsequent PR.

cc @janowicz 

Unit tests are included in PR #136.