### PR TITLE
Fixing matplotlib backend

### DIFF
--- a/pandana/network.py
+++ b/pandana/network.py
@@ -1,8 +1,6 @@
 from __future__ import division, print_function
 
 import matplotlib
-# this might fix the travis build
-matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd


### PR DESCRIPTION
This PR resolves issue #132, where a hardcoded Matplotlib setting was creating problems for downstream code. As far as I can tell, the setting was just an old attempt to make Travis tests run more smoothly and is no longer needed. 

### Testing

Confirmed that this fixes the problem, as described here: https://github.com/UDST/pandana/issues/132#issuecomment-638395255