### PR TITLE
Vectorized shortest path length

### DIFF
--- a/examples/shortest_path_example.py
+++ b/examples/shortest_path_example.py
@@ -18,6 +18,7 @@ from __future__ import print_function
 
 import os.path
 import sys
+import time
 
 import numpy as np
 import pandas as pd
@@ -45,16 +46,41 @@ store.close()
 print()
 
 # Demonstrate shortest path code
-print('Shortest path from first to last node:')
+print('Shortest path 1:')
 a = nodes.index[0]
 print(a)
 b = nodes.index[-1]
 print(b)
-# Note that the 'weight' is 1.0 for each link, so results aren't very interesting
+
 print(net.shortest_path(a,b))
 print(net.shortest_path_length(a,b))
-print(net.shortest_path_length(a,b,'weight'))
 
-nodes_a = [nodes.index[0], nodes.index[1]]
-nodes_b = [nodes.index[-1], nodes.index[-2]]
+print('Shortest path 2:')
+a = nodes.index[5]
+print(a)
+b = nodes.index[50]
+print(b)
+
+print(net.shortest_path(a,b))
+print(net.shortest_path_length(a,b))
+
+print('Repeat with vectorized calculations:')
+nodes_a = [nodes.index[0], nodes.index[5]]
+nodes_b = [nodes.index[-1], nodes.index[50]]
 print(net.shortest_path_lengths(nodes_a, nodes_b))
+
+# Performance comparison
+print('Performance comparison for 10k distance calculations:')
+n = 10000
+
+nodes_a = np.random.choice(nodes.index, n)
+nodes_b = np.random.choice(nodes.index, n)
+
+t0 = time.time()
+for i in range(n):
+    _ = net.shortest_path_length(nodes_a[i], nodes_b[i])
+print('Loop time = {} sec'.format(time.time() - t0))
+
+t0 = time.time()
+_ = net.shortest_path_lengths(nodes_a, nodes_b)
+print('Vectorized time = {} sec'.format(time.time() - t0))

--- a/examples/shortest_path_example.py
+++ b/examples/shortest_path_example.py
@@ -52,4 +52,9 @@ b = nodes.index[-1]
 print(b)
 # Note that the 'weight' is 1.0 for each link, so results aren't very interesting
 print(net.shortest_path(a,b))
+print(net.shortest_path_length(a,b))
 print(net.shortest_path_length(a,b,'weight'))
+
+nodes_a = [nodes.index[0], nodes.index[1]]
+nodes_b = [nodes.index[-1], nodes.index[-2]]
+print(net.shortest_path_lengths(nodes_a, nodes_b))

--- a/examples/shortest_path_example.py
+++ b/examples/shortest_path_example.py
@@ -45,36 +45,36 @@ net = pdna.Network(nodes.x, nodes.y, edges["from"], edges.to,
 store.close()
 print()
 
-# Demonstrate shortest path code
-print('Shortest path 1:')
-a = nodes.index[0]
-print(a)
-b = nodes.index[-1]
-print(b)
+# Demonstrate shortest path code - the largest connected subgraph here has 477 nodes,
+# per the unit tests
 
-print(net.shortest_path(a,b))
-print(net.shortest_path_length(a,b))
+net.set(pd.Series(net.node_ids))
+s = net.aggregate(10000, type='count')
+connected_nodes = s[s==477]
+
+n = 10000
+nodes_a = np.random.choice(connected_nodes.index, n)
+nodes_b = np.random.choice(connected_nodes.index, n)
+
+print('Shortest path 1:')
+print(nodes_a[0])
+print(nodes_b[0])
+
+print(net.shortest_path(nodes_a[0],nodes_b[0]))
+print(net.shortest_path_length(nodes_a[0],nodes_b[0]))
 
 print('Shortest path 2:')
-a = nodes.index[5]
-print(a)
-b = nodes.index[50]
-print(b)
+print(nodes_a[1])
+print(nodes_b[1])
 
-print(net.shortest_path(a,b))
-print(net.shortest_path_length(a,b))
+print(net.shortest_path(nodes_a[1],nodes_b[1]))
+print(net.shortest_path_length(nodes_a[1],nodes_b[1]))
 
 print('Repeat with vectorized calculations:')
-nodes_a = [nodes.index[0], nodes.index[5]]
-nodes_b = [nodes.index[-1], nodes.index[50]]
-print(net.shortest_path_lengths(nodes_a, nodes_b))
+print(net.shortest_path_lengths(nodes_a[0:2],nodes_b[0:2]))
 
 # Performance comparison
 print('Performance comparison for 10k distance calculations:')
-n = 10000
-
-nodes_a = np.random.choice(nodes.index, n)
-nodes_b = np.random.choice(nodes.index, n)
 
 t0 = time.time()
 for i in range(n):

--- a/pandana/network.py
+++ b/pandana/network.py
@@ -258,6 +258,10 @@ class Network:
         list of floats
 
         """
+        if len(nodes_a) != len(nodes_b):
+            raise ValueError("Origin and destination counts don't match: {}, {}"\
+                .format(len(nodes_a), len(nodes_b)))
+        
         # map to internal node indexes
         nodes_a_idx = self._node_indexes(pd.Series(nodes_a)).values
         nodes_b_idx = self._node_indexes(pd.Series(nodes_b)).values

--- a/pandana/network.py
+++ b/pandana/network.py
@@ -202,7 +202,7 @@ class Network:
         # map back to external node ids
         return self.node_ids.values[path]
 
-    def shortest_path_length(self, node_a, node_b, imp_name):
+    def shortest_path_length(self, node_a, node_b, imp_name=None):
         """
         Return the length of the shortest path between two node ids in the
         network. Requires an impedance metric.
@@ -231,6 +231,36 @@ class Network:
         len = self.net.shortest_path_distance(node_a, node_b, imp_num)
 
         return len
+
+    def shortest_path_lengths(self, nodes_a, nodes_b, imp_name=None):
+        """
+        Vectorized calculation of shortest path lengths. Accepts a list of
+        origins and list of destinations and returns a corresponding list
+        of shortest path lengths. Requires an impedance metric.
+
+        Parameters
+        ----------
+        nodes_a : list-like of ints
+             Source nodes
+        nodes_b : list-like of ints
+             Corresponding destination nodes
+        imp_name : string
+            The impedance name to use for the shortest path
+
+        Returns
+        -------
+        np.ndarray of floats
+
+        """
+        # map to internal node indexes
+        nodes_a_idx = self._node_indexes(pd.Series(nodes_a)).values
+        nodes_b_idx = self._node_indexes(pd.Series(nodes_b)).values
+
+        imp_num = self._imp_name_to_num(imp_name)
+
+        lens = self.net.shortest_path_distances(nodes_a_idx, nodes_b_idx, imp_num)
+
+        return lens
 
     def set(self, node_ids, variable=None, name="tmp"):
         """

--- a/pandana/network.py
+++ b/pandana/network.py
@@ -173,14 +173,15 @@ class Network:
 
     def shortest_path(self, node_a, node_b, imp_name=None):
         """
-        Return the shortest path between two node ids in the network.
+        Return the shortest path between two node ids in the network. Must
+        provide an impedance name if more than one is available.
 
         Parameters
         ----------
         node_a : int
-             The source node label
+            Source node id
         node_b : int
-             The destination node label
+            Destination node id
         imp_name : string, optional
             The impedance name to use for the shortest path
 
@@ -205,14 +206,18 @@ class Network:
     def shortest_path_length(self, node_a, node_b, imp_name=None):
         """
         Return the length of the shortest path between two node ids in the
-        network. Requires an impedance metric.
+        network. Must provide an impedance name if more than one is
+        available. 
+        
+        If you have a large number of paths to calculate, don't use this
+        function! Use the vectorized one instead.
 
         Parameters
         ----------
         node_a : int
-             The source node label
+            Source node id
         node_b : int
-             The destination node label
+            Destination node id
         imp_name : string
             The impedance name to use for the shortest path
 
@@ -236,20 +241,21 @@ class Network:
         """
         Vectorized calculation of shortest path lengths. Accepts a list of
         origins and list of destinations and returns a corresponding list
-        of shortest path lengths. Requires an impedance metric.
+        of shortest path lengths. Must provide an impedance name if more
+        than one is available.
 
         Parameters
         ----------
         nodes_a : list-like of ints
-             Source nodes
+            Source node ids
         nodes_b : list-like of ints
-             Corresponding destination nodes
+            Corresponding destination node ids
         imp_name : string
             The impedance name to use for the shortest path
 
         Returns
         -------
-        np.ndarray of floats
+        list of floats
 
         """
         # map to internal node indexes

--- a/pandana/network.py
+++ b/pandana/network.py
@@ -207,8 +207,8 @@ class Network:
         """
         Return the length of the shortest path between two node ids in the
         network. Must provide an impedance name if more than one is
-        available. 
-        
+        available.
+
         If you have a large number of paths to calculate, don't use this
         function! Use the vectorized one instead.
 

--- a/pandana/tests/test_pandana.py
+++ b/pandana/tests/test_pandana.py
@@ -268,6 +268,29 @@ def test_shortest_path(sample_osm):
         assert ids[1] == path[-1]
 
 
+def test_shortest_path_length(sample_osm):
+
+    for i in range(10):
+        ids = random_connected_nodes(sample_osm, 2)
+        len = sample_osm.shortest_path_length(ids[0], ids[1])
+        assert len >= 0
+
+
+def test_shortest_path_lengths(sample_osm):
+
+    nodes = random_connected_nodes(sample_osm, 100)
+    lens = sample_osm.shortest_path_lengths(nodes[0:50], nodes[50:100])
+    for len in lens:
+        assert len >=0
+    
+    # check mismatched OD lists
+    try:
+        lens = sample_osm.shortest_path_lengths(nodes[0:51], nodes[50:100])
+        assert 0
+    except ValueError as e:
+        pass
+
+
 def test_pois(sample_osm):
     net = sample_osm
 

--- a/src/accessibility.cpp
+++ b/src/accessibility.cpp
@@ -111,11 +111,11 @@ Accessibility::Distance(int src, int tgt, int graphno) {
 }
 
 
-std::deque<double>
-Accessibility::Distances(const std::deque<int> &sources, const std::deque<int> &targets,  
-                         const int graphno)
+std::vector<double>
+Accessibility::Distances(const vector<int> &sources, const vector<int> &targets,  
+                         int graphno)
 {                       
-    std::deque<double> distances;
+    vector<double> distances;
     auto target_it = targets.begin();
     for(const auto &src : sources) {
         if(target_it == targets.end())

--- a/src/accessibility.cpp
+++ b/src/accessibility.cpp
@@ -1,7 +1,6 @@
 #include "accessibility.h"
 #include <algorithm>
 #include <cmath>
-#include <deque>
 #include <utility>
 #include "graphalg.h"
 
@@ -12,7 +11,6 @@ using std::string;
 using std::vector;
 using std::pair;
 using std::make_pair;
-using std::deque;
 
 typedef std::pair<double, int> distance_node_pair;
 bool distance_node_pair_comparator(const distance_node_pair& l,
@@ -112,7 +110,7 @@ Accessibility::Distance(int src, int tgt, int graphno) {
 
 
 std::vector<double>
-Accessibility::Distances(const vector<int> &sources, const vector<int> &targets,  
+Accessibility::Distances(const vector<long> &sources, const vector<long> &targets,  
                          int graphno)
 {                       
     vector<double> distances;

--- a/src/accessibility.cpp
+++ b/src/accessibility.cpp
@@ -114,8 +114,8 @@ Accessibility::Distances(const vector<long> &sources, const vector<long> &target
                          int graphno)
 {                       
     vector<double> distances;
-    auto target_it = targets.begin();
-    for(const auto &src : sources) {
+    vector<long>::const_iterator target_it = targets.begin();
+    for(const long &src : sources) {
         if(target_it == targets.end())
             break;
         distances.push_back(this->ga[graphno]->Distance(src, *target_it++));

--- a/src/accessibility.cpp
+++ b/src/accessibility.cpp
@@ -110,16 +110,20 @@ Accessibility::Distance(int src, int tgt, int graphno) {
 
 
 std::vector<double>
-Accessibility::Distances(const vector<long> &sources, const vector<long> &targets,  
-                         int graphno)
+Accessibility::Distances(vector<long> sources, vector<long> targets, int graphno)
 {                       
     vector<double> distances;
+    for (int i = 0 ; i < sources.size() ; i++) {
+        distances.push_back(this->ga[graphno]->Distance(sources[i], targets[i]));
+    }
+    /*
     vector<long>::const_iterator target_it = targets.begin();
     for(const long &src : sources) {
         if(target_it == targets.end())
             break;
         distances.push_back(this->ga[graphno]->Distance(src, *target_it++));
-    }   
+    }
+    */
     return distances;
 }
 

--- a/src/accessibility.cpp
+++ b/src/accessibility.cpp
@@ -1,7 +1,8 @@
-#include "accessibility.h"
 #include <algorithm>
 #include <cmath>
+#include <deque>
 #include <utility>
+#include "accessibility.h"
 #include "graphalg.h"
 
 namespace MTC {
@@ -11,6 +12,7 @@ using std::string;
 using std::vector;
 using std::pair;
 using std::make_pair;
+using std::deque;
 
 typedef std::pair<double, int> distance_node_pair;
 bool distance_node_pair_comparator(const distance_node_pair& l,
@@ -106,6 +108,21 @@ Accessibility::Route(int src, int tgt, int graphno) {
 double
 Accessibility::Distance(int src, int tgt, int graphno) {
     return this->ga[graphno]->Distance(src, tgt);
+}
+
+
+std::deque<double>
+Accessibility::Distances(const std::deque<int> &sources, const std::deque<int> &targets,  
+                         const int graphno)
+{                       
+    std::deque<double> distances;
+    auto target_it = targets.begin();
+    for(const auto &src : sources) {
+        if(target_it == targets.end())
+            break;
+        distances.push_back(this->ga[graphno]->Distance(src, *target_it++));
+    }   
+    return distances;
 }
 
 

--- a/src/accessibility.cpp
+++ b/src/accessibility.cpp
@@ -110,20 +110,19 @@ Accessibility::Distance(int src, int tgt, int graphno) {
 
 
 std::vector<double>
-Accessibility::Distances(vector<long> sources, vector<long> targets, int graphno)
-{                       
-    vector<double> distances;
-    for (int i = 0 ; i < sources.size() ; i++) {
-        distances.push_back(this->ga[graphno]->Distance(sources[i], targets[i]));
+Accessibility::Distances(vector<long> sources, vector<long> targets, int graphno) {                       
+    
+    int n = std::min(sources.size(), targets.size()); // in case lists don't match
+    vector<double> distances (n);
+    
+    #pragma omp parallel
+    #pragma omp for schedule(guided)
+    for (int i = 0 ; i < n ; i++) {
+        distances[i] = this->ga[graphno]->Distance(
+            sources[i], 
+            targets[i], 
+            omp_get_thread_num());
     }
-    /*
-    vector<long>::const_iterator target_it = targets.begin();
-    for(const long &src : sources) {
-        if(target_it == targets.end())
-            break;
-        distances.push_back(this->ga[graphno]->Distance(src, *target_it++));
-    }
-    */
     return distances;
 }
 

--- a/src/accessibility.cpp
+++ b/src/accessibility.cpp
@@ -1,8 +1,8 @@
+#include "accessibility.h"
 #include <algorithm>
 #include <cmath>
 #include <deque>
 #include <utility>
-#include "accessibility.h"
 #include "graphalg.h"
 
 namespace MTC {

--- a/src/accessibility.h
+++ b/src/accessibility.h
@@ -6,6 +6,7 @@
 #include <string>
 #include <utility>
 #include <map>
+#include <deque>
 #include "shared.h"
 #include "graphalg.h"
 
@@ -16,6 +17,7 @@ using std::vector;
 using std::string;
 using std::set;
 using std::map;
+using std::deque;
 
 class Accessibility {
  public:
@@ -50,8 +52,13 @@ class Accessibility {
 
     // shortest path between two points
     vector<int> Route(int src, int tgt, int graphno = 0);
+
     // shortest path distance between two points
     double Distance(int src, int tgt, int graphno = 0);
+    
+    // shortest path distances between list of origins and destinations
+    deque<double> Distances(const deque<int> &sources, const deque<int> &targets,  
+                            const int graphno = 0);
 
     // precompute the range queries and reuse them
     void precomputeRangeQueries(float radius);

--- a/src/accessibility.h
+++ b/src/accessibility.h
@@ -6,7 +6,6 @@
 #include <string>
 #include <utility>
 #include <map>
-#include <deque>
 #include "shared.h"
 #include "graphalg.h"
 
@@ -17,7 +16,6 @@ using std::vector;
 using std::string;
 using std::set;
 using std::map;
-using std::deque;
 
 class Accessibility {
  public:
@@ -57,8 +55,8 @@ class Accessibility {
     double Distance(int src, int tgt, int graphno = 0);
     
     // shortest path distances between list of origins and destinations
-    deque<double> Distances(const deque<int> &sources, const deque<int> &targets,  
-                            const int graphno = 0);
+    vector<double> Distances(const vector<int> &sources, const vector<int> &targets,  
+                             int graphno = 0);
 
     // precompute the range queries and reuse them
     void precomputeRangeQueries(float radius);

--- a/src/accessibility.h
+++ b/src/accessibility.h
@@ -55,7 +55,7 @@ class Accessibility {
     double Distance(int src, int tgt, int graphno = 0);
     
     // shortest path distances between list of origins and destinations
-    vector<double> Distances(const vector<long> &sources, const vector<long> &targets,  
+    vector<double> Distances(vector<long> sources, vector<long> targets,  
                              int graphno = 0);
 
     // precompute the range queries and reuse them

--- a/src/accessibility.h
+++ b/src/accessibility.h
@@ -55,7 +55,7 @@ class Accessibility {
     double Distance(int src, int tgt, int graphno = 0);
     
     // shortest path distances between list of origins and destinations
-    vector<double> Distances(const vector<int> &sources, const vector<int> &targets,  
+    vector<double> Distances(const vector<long> &sources, const vector<long> &targets,  
                              int graphno = 0);
 
     // precompute the range queries and reuse them

--- a/src/cyaccess.pyx
+++ b/src/cyaccess.pyx
@@ -172,5 +172,18 @@ cdef class cyaccess:
         """
         return self.access.Distance(srcnode, destnode, impno)
 
+    def shortest_path_distances(
+        self, 
+        np.ndarray[int] srcnodes, 
+        np.ndarray[int] destnodes, 
+        int impno=0
+    ):
+        """
+        srcnodes - node id origins
+        destnodes - node id destinations
+        impno - the impedance id to use
+        """
+        return self.access.Distances(srcnodes, destnodes, impno)
+
     def precompute_range(self, double radius):
         self.access.precomputeRangeQueries(radius)

--- a/src/cyaccess.pyx
+++ b/src/cyaccess.pyx
@@ -172,16 +172,12 @@ cdef class cyaccess:
         """
         return self.access.Distance(srcnode, destnode, impno)
 
-    def shortest_path_distances(
-        self, 
-        np.ndarray[int] srcnodes, 
-        np.ndarray[int] destnodes, 
-        int impno=0
-    ):
+    def shortest_path_distances(self, np.ndarray[int] srcnodes, 
+            np.ndarray[int] destnodes, int impno=0):
         """
-        srcnodes - node id origins
-        destnodes - node id destinations
-        impno - the impedance id to use
+        srcnodes - node ids of origins
+        destnodes - node ids of destinations
+        impno - impedance id
         """
         return self.access.Distances(srcnodes, destnodes, impno)
 

--- a/src/cyaccess.pyx
+++ b/src/cyaccess.pyx
@@ -25,7 +25,7 @@ cdef extern from "accessibility.h" namespace "MTC::accessibility":
             float, string, string, string, int)
         vector[int] Route(int, int, int)
         double Distance(int, int, int)
-        vector[double] Distances(vector[int], vector[int], int)
+        vector[double] Distances(vector[long], vector[long], int)
         void precomputeRangeQueries(double)
 
 
@@ -173,8 +173,8 @@ cdef class cyaccess:
         """
         return self.access.Distance(srcnode, destnode, impno)
 
-    def shortest_path_distances(self, np.ndarray[int] srcnodes, 
-            np.ndarray[int] destnodes, int impno=0):
+    def shortest_path_distances(self, np.ndarray[long] srcnodes, 
+            np.ndarray[long] destnodes, int impno=0):
         """
         srcnodes - node ids of origins
         destnodes - node ids of destinations

--- a/src/cyaccess.pyx
+++ b/src/cyaccess.pyx
@@ -25,6 +25,7 @@ cdef extern from "accessibility.h" namespace "MTC::accessibility":
             float, string, string, string, int)
         vector[int] Route(int, int, int)
         double Distance(int, int, int)
+        vector[double] Distances(vector[int], vector[int], int)
         void precomputeRangeQueries(double)
 
 


### PR DESCRIPTION
This PR extends #134 to provide vectorized calculation of the shortest path length for many OD pairs at once. It achieves this by running a loop on the C++ side, which performs much better than calling a Python function multiple times.

Thanks to @federicofernandez for help with the C++ code. 

### Comments on the Python API?

I'm leaving the other Python method too, so now we have both:
- `network.shortest_path_length()` (PR #134, takes one OD pair)
- `network.shortest_path_lengths()` (this PR, takes multiple OD pairs)

Is this too confusing? I feel like it might be useful to have both. Note that there's also `network.shortest_path()`, which has been in the Python API for a while and provides the path itself (sequence of nodes) for a single OD pair.

### Performance and accuracy

Thanks to @jessicacamacho for help with testing. 

Moving the loop to the C++ side improves performance about 100x-1000x for large numbers of OD pairs, depending on particular details of the use case. (Long routes in large networks see performance improvement at the lower end, because the Python overhead is a smaller portion of the computation time.)

The vectorization also takes advantage of multi-threading, if enabled by the compiler, which speeds things up about 2x on my 4-core machine.

The lengths themselves are very close to those calculated by NetworkX (which uses Dijkstra without contraction hierarchies) using an equivalent OSMNx network.

### Other changes

I also adjusted docstrings for some of the other shortest path Python functions, so that they more accurately reflect what the underlying C++ code is doing.

### To do:

I see there's a compilation problem in Windows Python 2.7...
https://ci.appveyor.com/project/smmaurer/pandana/builds/33281145/job/u5hh4ekphfyvi0d6

- [x] fix win py27 compilation if possible
- [x] add check for mismatched OD lists
- [x] add unit tests
- [x] test accuracy of the shortest path lengths