### PR TITLE
Compilation fixes for MacOS 10.15 Catalina

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,8 +69,19 @@ if sys.platform.startswith('darwin'):  # Mac
     
     # This checks if the user has replaced the default clang compiler (this does
     # not confirm there's OpenMP support, but is the best we could come up with)
-    if os.popen('which clang').read() != '/usr/bin/clang':
-        os.environ['CC'] = 'clang'
+    if os.popen('which clang').read().strip() != '/usr/bin/clang':
+        
+        # C++ headers are in a new location in MacOS 10.15 Catalina
+        if '10.15' in os.popen('sw_vers').read():
+            os.environ['CC'] = 'clang --sysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk'
+
+        # Guessing it will be the same in 10.16, but we'll see
+        elif '10.16' in os.popen('sw_vers').read():
+            os.environ['CC'] = 'clang --sysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk'
+
+        else:
+            os.environ['CC'] = 'clang'
+
         extra_compile_args += ['-fopenmp']
 
 # Window compilation: flags are for Visual C++

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ if sys.platform.startswith('darwin'):  # Mac
     
     # This environment variable sets the earliest OS version that the compiled
     # code will be compatible with. In certain contexts the default is too old
-    # to allow using libc++; supporting OS X 10.9 and later seems safe
+    # to allow using libc++; supporting OS X 10.9 and later seems reasonable
     os.environ['MACOSX_DEPLOYMENT_TARGET'] = '10.9'
     
     extra_compile_args += ['-D NO_TR1_MEMORY', '-stdlib=libc++']


### PR DESCRIPTION
This PR updates `setup.py` in order to support Pandana compilation in MacOS 10.15 Catalina, as discussed in issue #129. The system's C++ headers were moved, so the script now detects which version of the operating system is present and uses the appropriate header path. This PR also improves support for custom compilers on Mac.

### New usage

Installing Pandana from Conda Forge gives you pre-compiled binaries. Installing from Pip or from source code requires local compilation. (Pip binaries are a lot harder for us to provide than Conda Forge binaries, so we had to drop them.)

Here's how local compilation works on Mac:

All Macs will need Xcode command line tools in order to do the local compilation.
```
xcode-select --install
```

At this point, you can do one of the following:

1. Use the system's default compiler. This is the easiest if you're not using Anaconda, but will not support multi-threading in Pandana.

```
pip install cython numpy
pip install -e .  # or 'pip install pandana' for a production release
```

2. Use the Conda toolchain. This is what we recommend.

```
conda install cython numpy llvm-openmp clang
pip install -e .
```

3. Use a compiler of your choice, if you want multi-threading support but don't like Anaconda. Homebrew is a common alternative. As of this PR, we now detect whether you've set a `CC` environment variable, and if so we use whichever compiler you specify.

```
export CC=/your/favorite/compiler
pip install cython numpy
pip install -e .
```

### Testing

- [ ] compilation on 10.14 using system compiler
- [ ] compilation on 10.14 using Conda toolchain
- [x] compilation on 10.15 using system compiler
- [x] compilation on 10.15 using Conda toolchain
- [x] compilation with `CC` set manually
