### PR TITLE
[v0.6.dev0] Vectorized shortest-path routes

### DIFF
--- a/examples/shortest_path_example.py
+++ b/examples/shortest_path_example.py
@@ -71,6 +71,7 @@ print(net.shortest_path(nodes_a[1],nodes_b[1]))
 print(net.shortest_path_length(nodes_a[1],nodes_b[1]))
 
 print('Repeat with vectorized calculations:')
+print(net.shortest_paths(nodes_a[0:2],nodes_b[0:2]))
 print(net.shortest_path_lengths(nodes_a[0:2],nodes_b[0:2]))
 
 # Performance comparison
@@ -78,9 +79,18 @@ print('Performance comparison for 10k distance calculations:')
 
 t0 = time.time()
 for i in range(n):
+    _ = net.shortest_path(nodes_a[i], nodes_b[i])
+print('Route loop time = {} sec'.format(time.time() - t0))
+
+t0 = time.time()
+_ = net.shortest_paths(nodes_a, nodes_b)
+print('Route vectorized time = {} sec'.format(time.time() - t0))
+
+t0 = time.time()
+for i in range(n):
     _ = net.shortest_path_length(nodes_a[i], nodes_b[i])
-print('Loop time = {} sec'.format(time.time() - t0))
+print('Distance loop time = {} sec'.format(time.time() - t0))
 
 t0 = time.time()
 _ = net.shortest_path_lengths(nodes_a, nodes_b)
-print('Vectorized time = {} sec'.format(time.time() - t0))
+print('Distance vectorized time = {} sec'.format(time.time() - t0))

--- a/pandana/__init__.py
+++ b/pandana/__init__.py
@@ -1,3 +1,3 @@
 from .network import Network
 
-version = __version__ = '0.5.1.dev0'
+version = __version__ = '0.6.dev0'

--- a/pandana/__init__.py
+++ b/pandana/__init__.py
@@ -1,3 +1,3 @@
 from .network import Network
 
-version = __version__ = '0.5'
+version = __version__ = '0.5.1.dev0'

--- a/pandana/network.py
+++ b/pandana/network.py
@@ -199,11 +199,10 @@ class Network:
         # map back to external node ids
         return self.node_ids.values[path]
 
-
     def shortest_paths(self, nodes_a, nodes_b, imp_name=None):
         """
         Vectorized calculation of shortest paths. Accepts a list of origins
-        and list of destinations and returns a corresponding list of 
+        and list of destinations and returns a corresponding list of
         shortest path routes. Must provide an impedance name if more than
         one is available.
 
@@ -218,7 +217,7 @@ class Network:
 
         Returns
         -------
-        paths : list of np.ndarrays
+        paths : list of np.ndarray
             Nodes traversed in each shortest path
 
         """
@@ -234,9 +233,8 @@ class Network:
 
         paths = self.net.shortest_paths(nodes_a_idx, nodes_b_idx, imp_num)
 
-        # TODO: this line needs to be fully vectorized for optimal performance
+        # map back to external node ids
         return [self.node_ids.values[p] for p in paths]
-
 
     def shortest_path_length(self, node_a, node_b, imp_name=None):
         """
@@ -272,7 +270,6 @@ class Network:
 
         return len
 
-
     def shortest_path_lengths(self, nodes_a, nodes_b, imp_name=None):
         """
         Vectorized calculation of shortest path lengths. Accepts a list of
@@ -307,7 +304,6 @@ class Network:
         lens = self.net.shortest_path_distances(nodes_a_idx, nodes_b_idx, imp_num)
 
         return lens
-
 
     def set(self, node_ids, variable=None, name="tmp"):
         """

--- a/pandana/network.py
+++ b/pandana/network.py
@@ -199,6 +199,44 @@ class Network:
         # map back to external node ids
         return self.node_ids.values[path]
 
+
+    def shortest_paths(self, nodes_a, nodes_b, imp_name=None):
+        """
+        Vectorized calculation of shortest paths. Accepts a list of origins
+        and list of destinations and returns a corresponding list of 
+        shortest path lengths. Must provide an impedance name if more than
+        one is available.
+
+        Parameters
+        ----------
+        nodes_a : list-like of ints
+            Source node ids
+        nodes_b : list-like of ints
+            Corresponding destination node ids
+        imp_name : string
+            The impedance name to use for the shortest path
+
+        Returns
+        -------
+        lenths : list of np.ndarrays
+            Nodes traversed in each shortest path
+
+        """
+        if len(nodes_a) != len(nodes_b):
+            raise ValueError("Origin and destination counts don't match: {}, {}"
+                             .format(len(nodes_a), len(nodes_b)))
+
+        # map to internal node indexes
+        nodes_a_idx = self._node_indexes(pd.Series(nodes_a)).values
+        nodes_b_idx = self._node_indexes(pd.Series(nodes_b)).values
+
+        imp_num = self._imp_name_to_num(imp_name)
+
+        paths = self.net.shortest_paths(nodes_a_idx, nodes_b_idx, imp_num)
+
+        return [self.node_ids.values[p] for p in paths]
+
+
     def shortest_path_length(self, node_a, node_b, imp_name=None):
         """
         Return the length of the shortest path between two node ids in the
@@ -232,6 +270,7 @@ class Network:
         len = self.net.shortest_path_distance(node_a, node_b, imp_num)
 
         return len
+
 
     def shortest_path_lengths(self, nodes_a, nodes_b, imp_name=None):
         """
@@ -267,6 +306,7 @@ class Network:
         lens = self.net.shortest_path_distances(nodes_a_idx, nodes_b_idx, imp_num)
 
         return lens
+
 
     def set(self, node_ids, variable=None, name="tmp"):
         """

--- a/pandana/network.py
+++ b/pandana/network.py
@@ -204,7 +204,7 @@ class Network:
         """
         Vectorized calculation of shortest paths. Accepts a list of origins
         and list of destinations and returns a corresponding list of 
-        shortest path lengths. Must provide an impedance name if more than
+        shortest path routes. Must provide an impedance name if more than
         one is available.
 
         Parameters

--- a/pandana/network.py
+++ b/pandana/network.py
@@ -234,6 +234,7 @@ class Network:
 
         paths = self.net.shortest_paths(nodes_a_idx, nodes_b_idx, imp_num)
 
+        # TODO: this line needs to be fully vectorized for optimal performance
         return [self.node_ids.values[p] for p in paths]
 
 

--- a/pandana/network.py
+++ b/pandana/network.py
@@ -218,7 +218,7 @@ class Network:
 
         Returns
         -------
-        lenths : list of np.ndarrays
+        paths : list of np.ndarrays
             Nodes traversed in each shortest path
 
         """

--- a/pandana/tests/test_pandana.py
+++ b/pandana/tests/test_pandana.py
@@ -268,6 +268,23 @@ def test_shortest_path(sample_osm):
         assert ids[1] == path[-1]
 
 
+def test_shortest_paths(sample_osm):
+
+    nodes = random_connected_nodes(sample_osm, 100)
+    vec_paths = sample_osm.shortest_paths(nodes[0:50], nodes[50:100])
+
+    for i in range(50):
+        path = sample_osm.shortest_path(nodes[i], nodes[i+50])
+        assert(np.array_equal(vec_paths[i], path))
+
+    # check mismatched OD lists
+    try:
+        vec_paths = sample_osm.shortest_paths(nodes[0:51], nodes[50:100])
+        assert 0
+    except ValueError as e:
+        pass
+
+
 def test_shortest_path_length(sample_osm):
 
     for i in range(10):

--- a/setup.py
+++ b/setup.py
@@ -131,7 +131,7 @@ cyaccess = Extension(
 ## Standard setup
 ###############################################
 
-version = '0.5.1.dev0'
+version = '0.6.dev0'
 
 packages = find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"])
 

--- a/setup.py
+++ b/setup.py
@@ -131,7 +131,7 @@ cyaccess = Extension(
 ## Standard setup
 ###############################################
 
-version = '0.5'
+version = '0.5.1.dev0'
 
 packages = find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"])
 

--- a/src/accessibility.cpp
+++ b/src/accessibility.cpp
@@ -96,10 +96,27 @@ Accessibility::precomputeRangeQueries(float radius) {
 }
 
 
-std::vector<int>
+vector<int>
 Accessibility::Route(int src, int tgt, int graphno) {
     vector<NodeID> ret = this->ga[graphno]->Route(src, tgt);
     return vector<int> (ret.begin(), ret.end());
+}
+
+
+vector<vector<int>>
+Accessibility::Routes(vector<long> sources, vector<long> targets, int graphno) {
+
+    int n = std::min(sources.size(), targets.size()); // in case lists don't match
+    vector<vector<int>> routes(n);
+
+    #pragma omp parallel
+    #pragma omp for schedule(guided)
+    for (int i = 0 ; i < n ; i++) {
+        vector<NodeID> ret = this->ga[graphno]->Route(sources[i], targets[i], 
+            omp_get_thread_num());
+        routes[i] = vector<int> (ret.begin(), ret.end());
+    }
+    return routes;
 }
 
 
@@ -109,11 +126,11 @@ Accessibility::Distance(int src, int tgt, int graphno) {
 }
 
 
-std::vector<double>
+vector<double>
 Accessibility::Distances(vector<long> sources, vector<long> targets, int graphno) {                       
     
     int n = std::min(sources.size(), targets.size()); // in case lists don't match
-    vector<double> distances (n);
+    vector<double> distances(n);
     
     #pragma omp parallel
     #pragma omp for schedule(guided)

--- a/src/accessibility.h
+++ b/src/accessibility.h
@@ -51,6 +51,10 @@ class Accessibility {
     // shortest path between two points
     vector<int> Route(int src, int tgt, int graphno = 0);
 
+    // shortest path between list of origins and destinations
+    vector<vector<int>> Routes(vector<long> sources, vector<long> targets,  
+                             int graphno = 0);
+
     // shortest path distance between two points
     double Distance(int src, int tgt, int graphno = 0);
     

--- a/src/cyaccess.pyx
+++ b/src/cyaccess.pyx
@@ -24,6 +24,7 @@ cdef extern from "accessibility.h" namespace "MTC::accessibility":
         vector[double] getAllAggregateAccessibilityVariables(
             float, string, string, string, int)
         vector[int] Route(int, int, int)
+        vector[vector[int]] Routes(vector[long], vector[long], int)
         double Distance(int, int, int)
         vector[double] Distances(vector[long], vector[long], int)
         void precomputeRangeQueries(double)
@@ -164,6 +165,15 @@ cdef class cyaccess:
         impno - the impedance id to use
         """
         return self.access.Route(srcnode, destnode, impno)
+
+    def shortest_paths(self, np.ndarray[long] srcnodes, 
+            np.ndarray[long] destnodes, int impno=0):
+        """
+        srcnodes - node ids of origins
+        destnodes - node ids of destinations
+        impno - impedance id
+        """
+        return self.access.Routes(srcnodes, destnodes, impno)
 
     def shortest_path_distance(self, int srcnode, int destnode, int impno=0):
         """


### PR DESCRIPTION
This PR adds a function for getting the shortest-path routes between many origin–destination pairs at once. It's vectorized and multi-threaded for optimal performance.

- `network.shortest_paths()`

This is analogous to the work in PR #136 that vectorized the distance calculations. Thanks to @pavyedav for helpful discussions, code review, and testing.

### Performance

With a small-scale network, the vectorized function is about 150x faster than looping through the existing Python function that takes one O–D pair. See [shortest_path_example.py](https://github.com/UDST/pandana/blob/4cc472c/examples/shortest_path_example.py) for the benchmark code.

This is great, but it's not as fast as the vectorized distance calculations in #136, which had a 1200x improvement. My best guess is that this is because there are node id lookups that still use a Python loop ([network.py#L237-L238](https://github.com/UDST/pandana/blob/4cc472c/pandana/network.py#L237-L238)). So we should try to vectorize these with NumPy before merging -- SEE ADDITIONAL DISCUSSION IN COMMENTS.

The C++ code is also not quite as efficient -- it doesn't allocate all the memory in advance, because we don't know how many nodes each route will involve. I'm guessing this is not as big a deal, though. [accessibility.cpp#L106-L120](https://github.com/UDST/pandana/blob/4cc472c/src/accessibility.cpp#L106-L120)

### Discussion

Note that Pandana expresses routes in terms of a sequence of node id's, not edge id's. @pavyedav and I dug into this a bit and it seems to be baked in pretty deeply in the C++. So if you're working with data where the edge id's are important, the best approach is probably to set up a secondary index in Python that identifies the edges by their corresponding nodes, and use that to translate the Pandana route into a sequence of edges.

### To do:

- [x] vectorize the node id lookups ([network.py#L237-L238](https://github.com/UDST/pandana/blob/4cc472c5fa545d3bfac08cab21b7f5a45698456d/pandana/network.py#L237-L238))
- [x] add some unit tests