### PR TITLE
Require C++11

### DIFF
--- a/pandana/__init__.py
+++ b/pandana/__init__.py
@@ -1,3 +1,3 @@
 from .network import Network
 
-version = __version__ = '0.6'
+version = __version__ = '0.6.1.dev0'

--- a/setup.py
+++ b/setup.py
@@ -126,7 +126,7 @@ cyaccess = Extension(
 ## Standard setup
 ###############################################
 
-version = '0.6'
+version = '0.6.1.dev0'
 
 packages = find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"])
 

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ extra_link_args = []
 
 if sys.platform.startswith('darwin'):  # Mac
     
-    extra_compile_args += ['-D NO_TR1_MEMORY', '-stdlib=libc++']
+    extra_compile_args += ['-stdlib=libc++']
     extra_link_args += ['-stdlib=libc++']
     
     # The default compiler that ships with Macs doesn't support OpenMP multi-

--- a/src/accessibility.cpp
+++ b/src/accessibility.cpp
@@ -1,6 +1,7 @@
 #include "accessibility.h"
 #include <algorithm>
 #include <cmath>
+#include <functional>
 #include <utility>
 #include "graphalg.h"
 
@@ -16,22 +17,6 @@ typedef std::pair<double, int> distance_node_pair;
 bool distance_node_pair_comparator(const distance_node_pair& l,
                                    const distance_node_pair& r)
     { return l.first < r.first; }
-
-
-double exp_decay(const double &distance, const float &radius, const float &var)
-{
-	return exp(-1*distance/radius) * var;
-}
-
-double linear_decay(const double &distance, const float &radius, const float &var)
-{
-	return (1.0-distance/radius) * var;
-}
-
-double flat_decay(const double &distance, const float &radius, const float &var)
-{
-	return var;
-}
 
 
 Accessibility::Accessibility(
@@ -401,14 +386,17 @@ Accessibility::aggregateAccessibilityVariable(
     double sum = 0.0;
     double sumsq = 0.0;
 
-    double (*sum_function_ptr)(const double &, const float &, const float &);
+    std::function<double(const double &, const float &, const float &)> sum_function;
 
     if(decay == "exp")
-        sum_function_ptr = &exp_decay;
+        sum_function = [](const double &distance, const float &radius, const float &var)
+                        { return exp(-1*distance/radius) * var; };
     if(decay == "linear")
-        sum_function_ptr = &linear_decay;
+        sum_function = [](const double &distance, const float &radius, const float &var)
+                        { return (1.0-distance/radius) * var; };
     if(decay == "flat")
-        sum_function_ptr = &flat_decay;
+        sum_function = [](const double &distance, const float &radius, const float &var)
+                        { return var; };
 
     for (int i = 0 ; i < distances.size() ; i++) {
         int nodeid = distances[i].first;
@@ -419,7 +407,7 @@ Accessibility::aggregateAccessibilityVariable(
 
         for (int j = 0 ; j < vars[nodeid].size() ; j++) {
             cnt++;  // count items
-            sum += (*sum_function_ptr)(distance, radius, vars[nodeid][j]);
+            sum += sum_function(distance, radius, vars[nodeid][j]);
 
             // stddev is always flat
             sumsq += vars[nodeid][j] * vars[nodeid][j];

--- a/src/contraction_hierarchies/src/POIIndex/POIIndex.h
+++ b/src/contraction_hierarchies/src/POIIndex/POIIndex.h
@@ -22,18 +22,7 @@
 
 #include <vector>
 
-#if defined _WIN32 || defined NO_TR1_MEMORY
-#include <memory>
-#else
-// can we get rid of this tr1 stuff and use c++11 now?
-#include <tr1/memory>
-#endif
-
-#ifdef NO_TR1_MEMORY
- using std::shared_ptr;
-#else
-#define shared_ptr tr1::shared_ptr
-#endif
+using std::shared_ptr;
 
 #include "../BasicDefinitions.h"
 #include "../DataStructures/BinaryHeap.h"


### PR DESCRIPTION
This PR removes accommodations for pre-C++11 compilers, to streamline compilation on newer systems and allow us to use C++11 features. 

I believe we tried to do this earlier in the v0.4 release, but had to backpedal in order to continue building Pandana for Windows Python 2.7 environments. Now that we no longer support Python 2.7, we can go ahead with requiring C++11.

Changes:
- reverses the changes to `accessibility.cpp` from PR #123
- removes TR1 conditionals from `POIIndex.h` (TR1 was the precursor to the C++11 standard)

Testing:
- compiles and runs fine on my 10.15 Mac using (a) default clang and (b) conda toolchain clang
- opening the PR will also trigger compilation and unit tests on Ubuntu and Windows

Anything else we should include or test?