### PR TITLE
Fix build on non-x86

### DIFF
--- a/pandana/__init__.py
+++ b/pandana/__init__.py
@@ -1,3 +1,3 @@
 from .network import Network
 
-version = __version__ = '0.6.1.dev0'
+version = __version__ = '0.6.1.dev1'

--- a/setup.py
+++ b/setup.py
@@ -126,7 +126,7 @@ cyaccess = Extension(
 ## Standard setup
 ###############################################
 
-version = '0.6.1.dev0'
+version = '0.6.1.dev1'
 
 packages = find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"])
 

--- a/src/contraction_hierarchies/src/libch.cpp
+++ b/src/contraction_hierarchies/src/libch.cpp
@@ -20,7 +20,7 @@ or see http://www.gnu.org/licenses/agpl.txt.
 
 #include "libch.h"
 #include "POIIndex/POIIndex.h"
-#ifdef _OPENMP
+#if defined(_OPENMP) && (defined(__amd64__) || defined(__i386__))
 #include "Util/HyperThreading.h"
 #endif
 namespace CH {


### PR DESCRIPTION
cpuid is not available outside of amd64/i386.