### PR TITLE
Native support for ARM Macs

### DIFF
--- a/pandana/__init__.py
+++ b/pandana/__init__.py
@@ -1,3 +1,3 @@
 from .network import Network
 
-version = __version__ = '0.6.1.dev1'
+version = __version__ = '0.6.1.dev2'

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,7 @@ import platform
 import sys
 import sysconfig
 
-from setuptools import find_packages
-from distutils.core import setup, Extension
+from setuptools import find_packages, setup, Extension
 from setuptools.command.test import test as TestCommand
 from setuptools.command.build_ext import build_ext
 
@@ -58,7 +57,7 @@ extra_link_args = []
 # versions of Xcode Command Line Tools, or newer versions installed separately
 
 if sys.platform.startswith('darwin'):  # Mac
-    
+
     extra_compile_args += ['-stdlib=libc++']
     extra_link_args += ['-stdlib=libc++']
     
@@ -126,7 +125,7 @@ cyaccess = Extension(
 ## Standard setup
 ###############################################
 
-version = '0.6.1.dev1'
+version = '0.6.1.dev2'
 
 packages = find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"])
 


### PR DESCRIPTION
This PR updates the setup script to use `setuptools` in place of the older `distutils`, which on my test machine helped smooth out compilation on the new ARM-based Macs. 

Together with PR #158, this brings full support to the `dev` branch for compilation on these machines. For initial writeup see issue #152.

(Note that it's not a problem to run older x86 Python packages, including Pandana, on ARM Macs. These updates are just to support native compilation, which will improve performance.)

### How to compile natively on ARM Macs

1. Install MiniForge for `osx-arm64` ([read](https://conda-forge.org/blog/posts/2020-10-29-macos-arm64/), [download](https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-arm64.sh)).

2. Install all of Pandana's build- and runtime requirements from Conda. Check the install messages to confirm you're getting `osx-arm64` binaries. (If it's the normal `osx-64` binaries instead, you're probably running an x86 copy of Conda.)

   `conda install clang llvm-openmp cython numpy pandas scikit-learn pytables`

3. Compile and install Pandana.

   `python setup.py develop`

### Next steps to provide ARM binaries on Conda Forge

- [ ] merge this PR
- [ ] release v0.6.1
- [ ] open a PR adding Pandana to the list of packages for automated migration ([instructions](https://conda-forge.org/blog/posts/2020-10-29-macos-arm64/#how-to-add-a-osx-arm64-build-to-a-feedstock))
- [ ] confirm and test
- [ ] update install docs in README and sphinx

After that's completed, you'll be able to install Pandana for `osx-arm64` directly from Conda. 