### PR TITLE
Staging v0.6.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+v0.6.1
+======
+
+2021/03/17
+
+* Adds support for non-x86 CPUs, including ARM-based Macs
+* Removes accommodations for pre-C++11 compilers
+* Formally ends support for Python 2.7
+
 v0.6
 ====
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ As of March 2021, binary installers are provided for Mac, Linux, and Windows thr
 - `pip install pandana`
 - `conda install pandana --channel conda-forge`
 
-Pandana works best in Python 3.6+, although binary installers for Python 3.5 remain available on Pip. The last version of Pandana with Python 2.7 binaries is v0.4.4 on Conda Forge.
+Pandana is easiest to install in Python 3.6 to 3.9. The last version of Pandana with Python 2.7 binaries is v0.4.4 on Conda Forge. The last version with Python 3.5 binaries is v0.6 on Pip.
 
 See the documentation for information about other [installation options](http://udst.github.io/pandana/installation.html).
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Coverage Status](https://img.shields.io/badge/coverage-95%25-green)
+![Coverage Status](https://img.shields.io/badge/coverage-90%25-green)
 
 # Pandana
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,6 +1,15 @@
 Change log
 ==========
 
+v0.6.1
+------
+
+2021/03/17
+
+* Adds support for non-x86 CPUs, including ARM-based Macs
+* Removes accommodations for pre-C++11 compilers
+* Formally ends support for Python 2.7
+
 v0.6
 ----
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,7 +8,7 @@ Pandana
 
 Pandana is a Python library for network analysis that uses `contraction hierarchies <https://en.wikipedia.org/wiki/Contraction_hierarchies>`_ to calculate super-fast travel accessibility metrics and shortest paths. The numerical code is in C++.
 
-v0.6, released November 11, 2020. Docs updated March 2021.
+v0.6.1, released March 17, 2021.
 
 
 Acknowledgments

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -7,7 +7,7 @@ Pandana is a Python package that includes a C++ extension for numerical operatio
 Standard installation
 ------------------------------
 
-As of March 2021, binary installers are provided for Mac, Linux, and Windows through both PyPI and Conda Forge. 
+As of March 2021, binary installers are provided for Mac, Linux, and Windows through both PyPI and Conda Forge.
 
 You can install Pandana using Pip::
 
@@ -17,15 +17,15 @@ Or Conda::
 
     conda install pandana --channel conda-forge
 
-Pandana works best in Python 3.6+, although binary installers for Python 3.5 remain available on Pip. The last version of Pandana with Python 2.7 binaries is v0.4.4 on Conda Forge.
+Pandana is easiest to install in Python 3.6 to 3.9. The last version of Pandana with Python 2.7 binaries is v0.4.4 on Conda Forge. The last version with Python 3.5 binaries is v0.6 on Pip.
 
 
 ARM-based Macs
 ------------------------------
 
-Pandana's binary installers are optimized for x86 (Intel) Macs from 2020 and earlier, but will also run on newer ARM-based Macs.
+Native binary installers for ARM-based Macs are available on Conda Forge, but to use these your full Python stack needs to be optimized for ARM. 
 
-If you'd like to compile Pandana locally for ARM, see instructions in `issue #152 <https://github.com/UDST/pandana/issues/152>`_. In our testing, natively compiled binaries run about 35% faster than the x86 binaries with Rosetta translation. We aim to provide osx-arm64 binaries on Pip and Conda as soon as it's feasible.
+If you're running Python through Rosetta translation (which is the default), older Mac installers will continue to work fine. See `issue #152 <https://github.com/UDST/pandana/issues/152>`_ for tips and further discussion.
 
 
 Compiling from source code
@@ -35,7 +35,7 @@ You may want to compile Pandana locally if you're modifying the source code or n
 
 Mac users should start by running ``xcode-select --install`` to make sure you have Apple's Xcode command line tools, which are needed behind the scenes. Windows users will need the `Microsoft Visual C++ Build Tools <https://visualstudio.microsoft.com/visual-cpp-build-tools/>`_.
 
-Pandana's build-time requirements are ``cython``, ``numpy``, and a C++ compiler that supports the c++11 standard. Additionally, the compiler needs to support OpenMP to allow Pandana to use multithreading.
+Pandana's build-time requirements are ``cython``, ``numpy``, and a C++ compiler that supports the C++11 standard. Additionally, the compiler needs to support OpenMP to allow Pandana to use multithreading.
 
 The smoothest route is to get the compilers from Conda Forge -- you want the ``clang`` and ``llvm-openmp`` packages. Running Pandana's setup script will trigger compilation::
 
@@ -44,7 +44,7 @@ The smoothest route is to get the compilers from Conda Forge -- you want the ``c
 
 You'll see a lot of status messages go by, but hopefully no errors.
 
-MacOS 10.14 (but not later versions) often needs additional header files installed. If you see a compilation error like ``'wchar.h' file not found`` in MacOS 10.14, you can resolve it by running this command::
+MacOS 10.14 (but not newer versions) often needs additional header files installed. If you see a compilation error like ``'wchar.h' file not found`` in MacOS 10.14, you can resolve it by running this command::
 
     open /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg
 

--- a/pandana/__init__.py
+++ b/pandana/__init__.py
@@ -1,3 +1,3 @@
 from .network import Network
 
-version = __version__ = '0.6.1.dev2'
+version = __version__ = '0.6.1'

--- a/setup.py
+++ b/setup.py
@@ -125,7 +125,7 @@ cyaccess = Extension(
 ## Standard setup
 ###############################################
 
-version = '0.6.1.dev2'
+version = '0.6.1'
 
 packages = find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"])
 

--- a/setup.py
+++ b/setup.py
@@ -143,6 +143,7 @@ setup(
         'code is in C++.'),
     url='https://udst.github.io/pandana/',
     ext_modules=[cyaccess],
+    python_requires = '>=3.5',
     install_requires=[
         'cython >=0.25.2',
         'numpy >=1.8',
@@ -159,11 +160,11 @@ setup(
     },
     classifiers=[
         'Development Status :: 4 - Beta',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'License :: OSI Approved :: GNU Affero General Public License v3'
     ],
 )


### PR DESCRIPTION
This PR stages the v0.6.1 release. No changes to the functionality vs. v0.6, but some code streamlining and infrastructure improvements.

Previously merged:
- automated testing moved from Travis and AppVeyor to GitHub Actions (PR #153)
- workaround for dtype errors in Windows environments (PR #154)
- remove accommodations for pre-C++11 compilers (PR #155)
- build binary installers for PyPI in GitHub Actions (PR #157)
- allow builds on non-x86 (PR #158, thanks @pkubaj!)
- streamline support for ARM Macs (PR #159)

This PR:
- updates version numbers, changelogs, and docs
- formally ends support for Python 2.7

Release logistics:
- [x] update live docs
- [x] release on pypi
- [x] release on conda-forge
- [ ] merge dev to main and tag on GitHub