### PR TITLE
compat for numpy>=2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 requires = [
         "wheel",
         "setuptools >=40.8",
-        "cython >=0.25.2",
+        "cython >=3",
         "oldest-supported-numpy"
 ]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,6 @@ requires = [
         "wheel",
         "setuptools >=40.8",
         "cython >=3",
-        "oldest-supported-numpy"
+        "numpy>=2.0"
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -113,19 +113,15 @@ setup(
     url="https://udst.github.io/pandana/",
     ext_modules=[cyaccess],
     install_requires=[
-        'numpy >=1.8',
-        'pandas >=0.17',
+        'numpy >=2',
+        'pandas >=2',
         'requests >=2.0',
         'scikit-learn >=0.18',
         'tables >=3.1'
     ],
     classifiers=[
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "License :: OSI Approved :: GNU Affero General Public License v3",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ cyaccess = Extension(
 # Standard setup
 ###############################################
 
-version = "0.7"
+version = "0.7.1"
 
 packages = find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"])
 

--- a/src/cyaccess.pyx
+++ b/src/cyaccess.pyx
@@ -1,4 +1,4 @@
-#cython: language_level=3
+#cython: language_level=3str
 
 cimport cython
 from libcpp cimport bool

--- a/src/cyaccess.pyx
+++ b/src/cyaccess.pyx
@@ -8,6 +8,7 @@ from libcpp.pair cimport pair
 
 import numpy as np
 cimport numpy as np
+np.import_array()
 
 # resources
 # http://cython.readthedocs.io/en/latest/src/userguide/wrapping_CPlusPlus.html

--- a/tests/test_cyaccess.py
+++ b/tests/test_cyaccess.py
@@ -59,7 +59,7 @@ def test_agg_analysis(net, nodes_and_edges):
 
     # test missing aggregation type
     ret = net.get_all_aggregate_accessibility_variables(10, b'test', b'this is', b'bogus')
-    assert np.alltrue(np.isnan(ret))
+    assert np.all(np.isnan(ret))
 
 
 def test_poi_analysis(net, nodes_and_edges):


### PR DESCRIPTION
small updates to the build requirements (and one test) that use numpy >=2. With a new release, this should resolve #194 and https://github.com/conda-forge/pandana-feedstock/pull/28