### PR TITLE
Modernize builds for NumPy 2 and Python 3.14

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -1,65 +1,49 @@
-name: Build-wheels
-
-# This workflow builds "wheels", which are the binary package installers hosted on PyPI.
-# GitHub Actions is super helpful here because each one needs to be compiled in its own
-# target environment. The wheel files are saved as artifacts, which you can download from
-# the GitHub website. Wheels should be uploaded manually to PyPI -- see CONTRIBUTING.md.
-
-# The Linux wheels cannot be generated using `ubuntu-latest` because they require a
-# special Docker image to provide cross-Linux compatibility. There are at least a couple
-# of third-party actions set up using the official image; we could switch to another if
-# this ever breaks.
+name: Build wheels
 
 on:
-  # push:
   pull_request:
   release:
   workflow_dispatch:
 
 jobs:
+  build-wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
-  build-manylinux:
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build wheels
+      uses: pypa/cibuildwheel@v2.23
+      env:
+        CIBW_BUILD: "cp310-* cp311-* cp312-* cp313-* cp314-*"
+        CIBW_SKIP: "*-musllinux_*"
+        CIBW_TEST_REQUIRES: "pytest"
+        CIBW_TEST_COMMAND: "python -m pytest {project}/tests -q"
+    - name: Save artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: wheels-${{ matrix.os }}
+        path: wheelhouse/*.whl
+
+  build-sdist:
+    name: Build source distribution
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-#      with:
-#        ref: 'v0.6'  # enable to check out prior version of codebase
-    - name: Build wheels
-      uses: RalfG/python-wheels-manylinux-build@v0.5.0
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
       with:
-        python-versions: 'cp38-cp38 cp39-cp39 cp310-cp310 cp311-cp311'
-    - name: Save artifacts
-      uses: actions/upload-artifact@v2
-      with:
-        name: wheels
-        path: dist/*-manylinux*.whl
-
-  build:
-    runs-on: ${{ matrix.os }}
-    defaults:
-      run:
-        shell: bash -l {0}  # needed for conda persistence
-    strategy:
-      matrix:
-        os: [macos-latest, windows-latest]
-        python-version: [3.8, 3.9, '3.10', '3.11']
-    steps:
-    - uses: actions/checkout@v2
-#      with:
-#        ref: 'v0.6'  # enable to check out prior version of codebase
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: conda-incubator/setup-miniconda@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Set up environment
+        python-version: '3.14'
+    - name: Build sdist
       run: |
-        conda config --append channels conda-forge
-        conda install build clang llvm-openmp
-    - name: Build wheel
-      run: |
-        python -m build --sdist --wheel
-    - name: Save artifacts
-      uses: actions/upload-artifact@v2
+        python -m pip install --upgrade pip build
+        python -m build --sdist
+    - name: Save artifact
+      uses: actions/upload-artifact@v4
       with:
-        name: wheels
-        path: dist/*.whl
+        name: sdist
+        path: dist/*.tar.gz

--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -10,11 +10,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.x'
+        python-version: '3.14'
     - name: Check code style
       run: |
         pip install pycodestyle

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,40 +1,23 @@
 name: Coverage
 
-# This workflow generates a coverage report (how much of the codebase is covered by the
-# unit tests) and posts headline metrics to the PR thread.
-
 on:
-  # push:
   pull_request:
   workflow_dispatch:
 
 jobs:
-  build:
+  coverage:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.14'
     - name: Install Pandana
       run: |
-        pip install .
-        pip install osmnet
-
-# `coverage run ...` is failing in GitHub Actions, but I'm not able to reproduce the
-# problem locally. We should look into this again another time. (11-May-2021)
-
-#    - name: Generate coverage report
-#      run: |
-#        pip install pytest coverage
-#        coverage run --source pandana --module pytest --verbose
-#        coverage report --show-missing
-#        echo "coverage=$(coverage report | grep '^TOTAL' | grep -oE '[^ ]+$')" >> $GITHUB_ENV
-#    - name: Post comment on PR
-#      uses: unsplash/comment-on-pr@master
-#      env: 
-#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#      with:
-#        msg: "Test coverage is ${{ env.coverage }}"
-#        check_for_duplicate_msg: true
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install .
+        python -m pip install pytest pytest-cov
+    - name: Generate coverage report
+      run: |
+        python -m pytest --cov=pandana --cov-report=term-missing -q

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,6 +18,9 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install .
         python -m pip install pytest pytest-cov
+    - name: Build extension in source tree
+      run: |
+        python setup.py build_ext --inplace --force
     - name: Generate coverage report
       run: |
         python -m pytest --cov=pandana --cov-report=term-missing -q

--- a/.github/workflows/cross-compatibility.yml
+++ b/.github/workflows/cross-compatibility.yml
@@ -1,66 +1,32 @@
 name: Cross-compatibility
 
-# This workflow runs the Pandana unit tests across a comprehensive range of Python
-# versions and operating systems. Windows needs conda in order to install geospatial
-# dependencies.
-
 on:
-  # push:
   pull_request:
   workflow_dispatch:
 
 jobs:
-  build-pip:
+  test:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
-        python-version: [3.8, 3.9, '3.10', '3.11']
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Pandana
       run: |
-        pip install .
-        pip install osmnet
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install .
+        python -m pip install pytest
     - name: Run demo
       run: |
         python examples/simple_example.py
     - name: Run unit tests
       run: |
-        pip install pytest
-        pytest -s
-
-  build-conda:
-    runs-on: ${{ matrix.os }}
-    defaults:
-      run:
-        shell: bash -l {0}  # needed for conda persistence
-    strategy:
-      matrix:
-        os: [windows-latest]
-        python-version: [3.8, 3.9, '3.10', '3.11']
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: conda-incubator/setup-miniconda@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install Pandana
-      run: |
-        pip install .
-
-# OSMNet is causing a version of Pandas to be installed that crashes in GitHub Actions.
-# Assume this will resolve itself on its own. (11-May-2021)
-
-#        conda install osmnet --channel conda-forge
-    - name: Run demo
-      run: |
-        python examples/simple_example.py
-#    - name: Run unit tests
-#      run: |
-#        pip install pytest
-#        pytest -s
+        python -m pytest -q

--- a/.github/workflows/cross-compatibility.yml
+++ b/.github/workflows/cross-compatibility.yml
@@ -24,6 +24,9 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install .
         python -m pip install pytest
+    - name: Build extension in source tree
+      run: |
+        python setup.py build_ext --inplace --force
     - name: Run demo
       run: |
         python examples/simple_example.py

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,28 +1,24 @@
 name: Unit tests
 
-# This workflow runs the Pandana unit tests in a single generic environment (recent but
-# stable Python version on recent but stable Ubuntu). The cross-compatibility.yml
-# workflow runs the same tests across multiple platforms.
-
 on:
   push:
-  # pull_request:
+  pull_request:
   workflow_dispatch:
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.14'
     - name: Install Pandana
       run: |
-        pip install .
-        pip install osmnet
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install .
+        python -m pip install pytest
     - name: Run unit tests
       run: |
-        pip install pytest
-        pytest -s
+        python -m pytest -q

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -19,6 +19,9 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install .
         python -m pip install pytest
+    - name: Build extension in source tree
+      run: |
+        python setup.py build_ext --inplace --force
     - name: Run unit tests
       run: |
         python -m pytest -q

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ __pycache__/
 # Distribution / packaging
 .Python
 env/
+.venv/
+.venv313/
 bin/
 build/
 develop-eggs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+v0.7.1
+======
+
+Unreleased
+
+* Adds support for NumPy 2, Cython 3, Python 3.12+, and modern Windows builds.
+* Updates compiled extension dtype handling to use explicit 64-bit NumPy types.
+* Replaces removed C++ standard library APIs used by the contraction hierarchy backend.
+* Preserves shortest-path behavior on a fixed graph with regression coverage.
+* Adds compatibility handling for legacy Pandana HDF files with newer Pandas/PyTables.
+
 v0.7
 ====
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,4 +8,4 @@ include requirements-extras.txt
 include setup.cfg
 
 recursive-include examples *.ipynb *.py
-recursive-include src *.h *.cpp
+recursive-include src *.h *.cpp *.pyx

--- a/examples/simple_example.py
+++ b/examples/simple_example.py
@@ -19,8 +19,8 @@ from __future__ import print_function
 import os.path
 import sys
 
-import pandas as pd
 import pandana.network as pdna
+from pandana.loaders.pandash5 import _legacy_compatible_hdf_store
 
 if len(sys.argv) > 1:
     # allow test file to be passed as an argument
@@ -36,8 +36,7 @@ if not os.path.isfile(storef):
 
 print('Building network from file: {!r}'.format(storef))
 
-store = pd.HDFStore(storef, "r")
-nodes, edges = store.nodes, store.edges
+with _legacy_compatible_hdf_store(storef) as store:
+    nodes, edges = store.nodes.copy(), store.edges.copy()
 net = pdna.Network(nodes.x, nodes.y, edges["from"], edges.to,
                    edges[["weight"]])
-store.close()

--- a/pandana/__init__.py
+++ b/pandana/__init__.py
@@ -1,3 +1,3 @@
 from .network import Network
 
-version = __version__ = '0.7'
+version = __version__ = '0.7.1'

--- a/pandana/loaders/osm.py
+++ b/pandana/loaders/osm.py
@@ -121,11 +121,23 @@ def make_osm_query(query):
     data : dict
 
     """
-    osm_url = 'http://www.overpass-api.de/api/interpreter'
-    req = requests.get(osm_url, params={'data': query})
-    req.raise_for_status()
+    osm_urls = (
+        'https://overpass-api.de/api/interpreter',
+        'https://overpass.kumi.systems/api/interpreter',
+    )
+    headers = {'User-Agent': 'pandana Python package'}
 
-    return req.json()
+    last_error = None
+    for osm_url in osm_urls:
+        try:
+            req = requests.post(
+                osm_url, data={'data': query}, headers=headers, timeout=60)
+            req.raise_for_status()
+            return req.json()
+        except requests.RequestException as err:
+            last_error = err
+
+    raise last_error
 
 
 def build_node_query(lat_min, lng_min, lat_max, lng_max, tags=None):

--- a/pandana/loaders/pandash5.py
+++ b/pandana/loaders/pandash5.py
@@ -1,4 +1,75 @@
+import os
+import shutil
+import tempfile
+from contextlib import contextmanager
+
 import pandas as pd
+
+
+def _has_legacy_pandas_attrs(filename):
+    try:
+        import tables
+    except ImportError:
+        return False
+
+    with tables.open_file(filename, mode="r") as h5:
+        for node in h5.walk_nodes("/"):
+            attrs = node._v_attrs
+            for name in attrs._v_attrnames:
+                value = getattr(attrs, name)
+                if not isinstance(value, str) and hasattr(value, "decode"):
+                    return True
+
+    return False
+
+
+def _decode_legacy_pandas_attrs(filename, output_filename=None):
+    """
+    Normalize legacy Pandas HDF5 metadata written as byte strings.
+
+    Older Pandas/PyTables combinations stored attributes such as
+    ``pandas_type`` as bytes. Pandas 3 expects text when it reconstructs
+    storers, so decode those attributes before opening the file with
+    ``pd.HDFStore``.
+    """
+    try:
+        import tables
+    except ImportError:
+        return
+
+    target = output_filename or filename
+    if output_filename is not None:
+        shutil.copyfile(filename, output_filename)
+
+    with tables.open_file(target, mode="a") as h5:
+        for node in h5.walk_nodes("/"):
+            attrs = node._v_attrs
+            for name in attrs._v_attrnames:
+                value = getattr(attrs, name)
+                if isinstance(value, str) or not hasattr(value, "decode"):
+                    continue
+
+                setattr(attrs, name, value.decode("utf-8"))
+
+    return target
+
+
+@contextmanager
+def _legacy_compatible_hdf_store(filename, mode="r"):
+    temp_filename = None
+    store_filename = filename
+
+    if mode == "r" and _has_legacy_pandas_attrs(filename):
+        fd, temp_filename = tempfile.mkstemp(suffix=".h5")
+        os.close(fd)
+        store_filename = _decode_legacy_pandas_attrs(filename, temp_filename)
+
+    try:
+        with pd.HDFStore(store_filename, mode=mode) as store:
+            yield store
+    finally:
+        if temp_filename and os.path.exists(temp_filename):
+            os.remove(temp_filename)
 
 
 def remove_nodes(network, rm_nodes):
@@ -68,7 +139,7 @@ def network_from_pandas_hdf5(cls, filename):
     network : pandana.Network
 
     """
-    with pd.HDFStore(filename) as store:
+    with _legacy_compatible_hdf_store(filename) as store:
         nodes = store['nodes']
         edges = store['edges']
         two_way = store['two_way'][0]

--- a/pandana/network.py
+++ b/pandana/network.py
@@ -8,6 +8,9 @@ from .cyaccess import cyaccess
 from .loaders import pandash5 as ph5
 import warnings
 
+INDEX_DTYPE = np.int64
+FLOAT_DTYPE = np.float64
+
 
 def reserve_num_graphs(num):
     """
@@ -83,7 +86,7 @@ class Network:
         # node IDs are thus translated back and forth in the python layer,
         # which allows non-integer node IDs as well
         self.node_idx = pd.Series(
-            np.arange(len(nodes_df), dtype="int"), index=nodes_df.index
+            np.arange(len(nodes_df), dtype=INDEX_DTYPE), index=nodes_df.index
         )
 
         edges = pd.concat(
@@ -92,16 +95,18 @@ class Network:
         )
 
         self.net = cyaccess(
-            self.node_idx.values,
-            nodes_df.astype("double").values,
-            edges.values,
-            edges_df[edge_weights.columns].transpose().astype("double").values,
+            self.node_idx.to_numpy(dtype=INDEX_DTYPE, copy=False),
+            nodes_df.to_numpy(dtype=FLOAT_DTYPE, copy=False),
+            edges.to_numpy(dtype=INDEX_DTYPE, copy=False),
+            edges_df[edge_weights.columns]
+            .transpose()
+            .to_numpy(dtype=FLOAT_DTYPE, copy=False),
             twoway,
         )
 
         self._twoway = twoway
 
-        self.kdtree = KDTree(nodes_df.values)
+        self.kdtree = KDTree(nodes_df.to_numpy(dtype=FLOAT_DTYPE, copy=False))
 
     @classmethod
     def from_hdf5(cls, filename):
@@ -238,8 +243,12 @@ class Network:
             )
 
         # map to internal node indexes
-        nodes_a_idx = self._node_indexes(pd.Series(nodes_a)).values
-        nodes_b_idx = self._node_indexes(pd.Series(nodes_b)).values
+        nodes_a_idx = self._node_indexes(pd.Series(nodes_a)).to_numpy(
+            dtype=INDEX_DTYPE, copy=False
+        )
+        nodes_b_idx = self._node_indexes(pd.Series(nodes_b)).to_numpy(
+            dtype=INDEX_DTYPE, copy=False
+        )
 
         imp_num = self._imp_name_to_num(imp_name)
 
@@ -321,8 +330,12 @@ class Network:
             )
 
         # map to internal node indexes
-        nodes_a_idx = self._node_indexes(pd.Series(nodes_a)).values
-        nodes_b_idx = self._node_indexes(pd.Series(nodes_b)).values
+        nodes_a_idx = self._node_indexes(pd.Series(nodes_a)).to_numpy(
+            dtype=INDEX_DTYPE, copy=False
+        )
+        nodes_b_idx = self._node_indexes(pd.Series(nodes_b)).to_numpy(
+            dtype=INDEX_DTYPE, copy=False
+        )
 
         imp_num = self._imp_name_to_num(imp_name)
 
@@ -389,8 +402,8 @@ class Network:
 
         self.net.initialize_access_var(
             name.encode("utf-8"),
-            df.node_idx.values.astype("int"),
-            df[name].values.astype("double"),
+            df.node_idx.to_numpy(dtype=INDEX_DTYPE, copy=False),
+            df[name].to_numpy(dtype=FLOAT_DTYPE, copy=False),
         )
 
     def precompute(self, distance):
@@ -442,7 +455,8 @@ class Network:
         """
         imp_num = self._imp_name_to_num(imp_name)
         imp_name = self.impedance_names[imp_num]
-        ext_ids = self.node_idx.index.values
+        nodes = np.asarray(nodes, dtype=INDEX_DTYPE)
+        ext_ids = self.node_idx.index.to_numpy(dtype=INDEX_DTYPE, copy=False)
 
         raw_result = self.net.nodes_in_range(nodes, radius, imp_num, ext_ids)
         clean_result = pd.concat(
@@ -587,7 +601,9 @@ class Network:
         """
         xys = pd.DataFrame({"x": x_col, "y": y_col})
 
-        distances, indexes = self.kdtree.query(xys.values)
+        distances, indexes = self.kdtree.query(
+            xys.to_numpy(dtype=FLOAT_DTYPE, copy=False)
+        )
         indexes = np.transpose(indexes)[0]
         distances = np.transpose(distances)[0]
 
@@ -774,7 +790,10 @@ class Network:
         node_idx = self._node_indexes(node_ids)
 
         self.net.initialize_category(
-            maxdist, maxitems, category.encode("utf-8"), node_idx.values
+            maxdist,
+            maxitems,
+            category.encode("utf-8"),
+            node_idx.to_numpy(dtype=INDEX_DTYPE, copy=False),
         )
 
     def nearest_pois(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,9 @@
 [build-system]
 # Requirements for building the compiled package
 requires = [
+        "setuptools >=64",
         "wheel",
-        "setuptools >=40.8",
-        "cython >=0.25.2",
-        "oldest-supported-numpy"
+        "cython >=3.0.10",
+        "numpy >=2.0"
 ]
 build-backend = "setuptools.build_meta"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@
 coveralls
 numpydoc
 pycodestyle
-pytest>=3.6,<4.0
-pytest-cov<2.10
+pytest>=7
+pytest-cov
 sphinx
 sphinx_rtd_theme

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools import find_packages, setup, Extension
 # Building the C++ extension
 ###############################################
 
-extra_compile_args = ["-w", "-std=c++11", "-O3"]
+extra_compile_args = ["-w", "-std=c++17", "-O3"]
 extra_link_args = []
 
 # Mac compilation: flags are for the llvm compilers included with recent
@@ -67,7 +67,7 @@ if sys.platform.startswith("darwin"):  # Mac
 # Window compilation: flags are for Visual C++
 
 elif sys.platform.startswith("win"):  # Windows
-    extra_compile_args = ["/w", "/openmp"]
+    extra_compile_args = ["/w", "/openmp", "/std:c++17"]
 
 # Linux compilation: flags are for gcc 4.8 and later
 
@@ -85,6 +85,7 @@ cyaccess = Extension(
         'src/contraction_hierarchies/src/libch.cpp'],
     language='c++',
     include_dirs=['.', np.get_include()],
+    define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_20_API_VERSION")],
     extra_compile_args=extra_compile_args,
     extra_link_args=extra_link_args)
 
@@ -93,7 +94,7 @@ cyaccess = Extension(
 # Standard setup
 ###############################################
 
-version = "0.7"
+version = "0.7.1"
 
 packages = find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"])
 
@@ -102,7 +103,8 @@ setup(
     name="pandana",
     author="UrbanSim Inc.",
     version=version,
-    license="AGPL",
+    license="AGPL-3.0-or-later",
+    python_requires=">=3.10",
     description=("Python library for network analysis"),
     long_description=(
         "Pandana is a Python library for network analysis that uses "
@@ -113,19 +115,17 @@ setup(
     url="https://udst.github.io/pandana/",
     ext_modules=[cyaccess],
     install_requires=[
-        'numpy >=1.8',
-        'pandas >=0.17',
+        'numpy >=2.0',
+        'pandas >=2.2',
         'requests >=2.0',
-        'scikit-learn >=0.18',
-        'tables >=3.1'
+        'scikit-learn >=1.5',
+        'tables >=3.10'
     ],
     classifiers=[
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
-        "License :: OSI Approved :: GNU Affero General Public License v3",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
     ],
 )

--- a/src/accessibility.cpp
+++ b/src/accessibility.cpp
@@ -22,7 +22,7 @@ bool distance_node_pair_comparator(const distance_node_pair& l,
 
 Accessibility::Accessibility(
         int numnodes,
-        vector< vector<long>> edges,
+        vector< vector<PandanaNodeID>> edges,
         vector< vector<double>>  edgeweights,
         bool twoway) {
 
@@ -82,14 +82,14 @@ Accessibility::precomputeRangeQueries(float radius) {
 }
 
 
-vector<vector<pair<long, float>>>
-Accessibility::Range(vector<long> srcnodes, float radius, int graphno, 
-                     vector<long> ext_ids) {
+vector<vector<pair<PandanaNodeID, float>>>
+Accessibility::Range(vector<PandanaNodeID> srcnodes, float radius, int graphno,
+                     vector<PandanaNodeID> ext_ids) {
 
     // Set up a mapping between the external node ids and internal ones
-    std::unordered_map<long, int> int_ids(ext_ids.size());
+    std::unordered_map<PandanaNodeID, int> int_ids(ext_ids.size());
     for (int i = 0; i < ext_ids.size(); i++) {
-        int_ids.insert(pair<long, int>(ext_ids[i], i));
+        int_ids.insert(pair<PandanaNodeID, int>(ext_ids[i], i));
     }
     
     // use cached results if available
@@ -112,7 +112,7 @@ Accessibility::Range(vector<long> srcnodes, float radius, int graphno,
     // todo: check that performing an aggregation creates cache
 
     // Convert back to external node ids
-    vector<vector<pair<long, float>>> output(dists.size());
+    vector<vector<pair<PandanaNodeID, float>>> output(dists.size());
     for (int i = 0; i < dists.size(); i++) {
         output[i].resize(dists[i].size());
         for (int j = 0; j < dists[i].size(); j++) {
@@ -132,7 +132,7 @@ Accessibility::Route(int src, int tgt, int graphno) {
 
 
 vector<vector<int>>
-Accessibility::Routes(vector<long> sources, vector<long> targets, int graphno) {
+Accessibility::Routes(vector<PandanaNodeID> sources, vector<PandanaNodeID> targets, int graphno) {
 
     int n = std::min(sources.size(), targets.size()); // in case lists don't match
     vector<vector<int>> routes(n);
@@ -155,7 +155,10 @@ Accessibility::Distance(int src, int tgt, int graphno) {
 
 
 vector<double>
-Accessibility::Distances(vector<long> sources, vector<long> targets, int graphno) {                       
+Accessibility::Distances(
+        vector<PandanaNodeID> sources,
+        vector<PandanaNodeID> targets,
+        int graphno) {
     
     int n = std::min(sources.size(), targets.size()); // in case lists don't match
     vector<double> distances(n);
@@ -180,7 +183,7 @@ POI QUERIES
 
 
 void Accessibility::initializeCategory(const double maxdist, const int maxitems,
-                                       string category, vector<long> node_idx)
+                                       string category, vector<PandanaNodeID> node_idx)
 {
     accessibility_vars_t av;
     av.resize(this->numnodes);
@@ -193,10 +196,10 @@ void Accessibility::initializeCategory(const double maxdist, const int maxitems,
         ga[i]->initPOIIndex(category, this->maxdist, this->maxitems);
         // initialize for each node
         for (int j = 0 ; j < node_idx.size() ; j++) {
-            int node_id = node_idx[j];
+            int node_id = static_cast<int>(node_idx[j]);
 
             ga[i]->addPOIToIndex(category, node_id);
-            assert(node_id << av.size());
+            assert(node_id < av.size());
             av[node_id].push_back(j);
         }
     }
@@ -233,7 +236,7 @@ Accessibility::findNearestPOIs(int srcnode, float maxradius, unsigned number,
 
       for (int i = 0 ; i < vars[nodeid].size() ; i++) {
           distance_node_pairs.push_back(
-             make_pair(distance, vars[nodeid][i]));
+             make_pair(distance, static_cast<int>(vars[nodeid][i])));
       }
     }
 
@@ -286,15 +289,15 @@ AGGREGATION/ACCESSIBILITY QUERIES
 
 void Accessibility::initializeAccVar(
     string category,
-    vector<long> node_idx,
+    vector<PandanaNodeID> node_idx,
     vector<double> values) {
     accessibility_vars_t av;
     av.resize(this->numnodes);
     for (int i = 0 ; i < node_idx.size() ; i++) {
-        int node_id = node_idx[i];
+        int node_id = static_cast<int>(node_idx[i]);
         double val = values[i];
 
-        assert(node_id << av.size());
+        assert(node_id < av.size());
         av[node_id].push_back(val);
     }
     accessibilityVars[category] = av;

--- a/src/accessibility.h
+++ b/src/accessibility.h
@@ -21,19 +21,21 @@ class Accessibility {
  public:
     Accessibility(
         int numnodes,
-        vector< vector<long> > edges,
+        vector< vector<PandanaNodeID> > edges,
         vector< vector<double> >  edgeweights,
         bool twoway);
 
     // initialize the category number with POIs at the node_id locations
-    void initializeCategory(const double maxdist, const int maxitems, string category, vector<long> node_idx);
+    void initializeCategory(
+        const double maxdist, const int maxitems, string category,
+        vector<PandanaNodeID> node_idx);
 
     // find the nearest pois for all nodes in the network
     pair<vector<vector<double>>, vector<vector<int>>>
     findAllNearestPOIs(float maxradius, unsigned maxnumber,
                        string category, int graphno = 0);
 
-    void initializeAccVar(string category, vector<long> node_idx,
+    void initializeAccVar(string category, vector<PandanaNodeID> node_idx,
                           vector<double> values);
 
     // computes the accessibility for every node in the network
@@ -46,21 +48,21 @@ class Accessibility {
         int graphno = 0);
 
     // get nodes with a range for a specific list of source nodes
-    vector<vector<pair<long, float>>> Range(vector<long> srcnodes, float radius, 
-                                            int graphno, vector<long> ext_ids);
+    vector<vector<pair<PandanaNodeID, float>>> Range(vector<PandanaNodeID> srcnodes, float radius,
+                                                     int graphno, vector<PandanaNodeID> ext_ids);
 
     // shortest path between two points
     vector<int> Route(int src, int tgt, int graphno = 0);
 
     // shortest path between list of origins and destinations
-    vector<vector<int>> Routes(vector<long> sources, vector<long> targets,  
+    vector<vector<int>> Routes(vector<PandanaNodeID> sources, vector<PandanaNodeID> targets,
                                int graphno = 0);
 
     // shortest path distance between two points
     double Distance(int src, int tgt, int graphno = 0);
     
     // shortest path distances between list of origins and destinations
-    vector<double> Distances(vector<long> sources, vector<long> targets,  
+    vector<double> Distances(vector<PandanaNodeID> sources, vector<PandanaNodeID> targets,
                              int graphno = 0);
 
     // precompute the range queries and reuse them

--- a/src/contraction_hierarchies/src/Contractor/Contractor.h
+++ b/src/contraction_hierarchies/src/Contractor/Contractor.h
@@ -29,6 +29,7 @@ or see http://www.gnu.org/licenses/agpl.txt.
 #include "../DataStructures/Percent.h"
 #include "../DataStructures/BinaryHeap.h"
 #include <ctime>
+#include <random>
 #include <vector>
 #include <queue>
 #include <set>
@@ -36,7 +37,7 @@ or see http://www.gnu.org/licenses/agpl.txt.
 #include <limits>
 #ifdef _OPENMP
 #include <omp.h>
-#else
+#elif !defined(PANDANA_OMP_FALLBACK)
 #define omp_get_thread_num() 0
 #define omp_get_max_threads() 1
 #endif
@@ -233,7 +234,8 @@ public:
 #pragma omp parallel for schedule ( guided )
         for ( int x = 0; x < ( int ) numberOfNodes; ++x )
             remainingNodes[x].first = x;
-        std::random_shuffle( remainingNodes.begin(), remainingNodes.end() );
+        std::mt19937 randomGenerator(0);
+        std::shuffle( remainingNodes.begin(), remainingNodes.end(), randomGenerator );
         for ( int x = 0; x < ( int ) numberOfNodes; ++x )
             nodeData[remainingNodes[x].first].bias = x;
 

--- a/src/cyaccess.pyx
+++ b/src/cyaccess.pyx
@@ -1,6 +1,7 @@
 #cython: language_level=3
 
 cimport cython
+from libc.stdint cimport int64_t
 from libcpp cimport bool
 from libcpp.vector cimport vector
 from libcpp.string cimport string
@@ -9,6 +10,8 @@ from libcpp.pair cimport pair
 import numpy as np
 cimport numpy as np
 
+np.import_array()
+
 # resources
 # http://cython.readthedocs.io/en/latest/src/userguide/wrapping_CPlusPlus.html
 # http://www.birving.com/blog/2014/05/13/passing-numpy-arrays-between-python-and/
@@ -16,45 +19,54 @@ cimport numpy as np
 
 cdef extern from "accessibility.h" namespace "MTC::accessibility":
     cdef cppclass Accessibility:
-        Accessibility(int, vector[vector[long]], vector[vector[double]], bool) except +
+        Accessibility(int, vector[vector[int64_t]], vector[vector[double]], bool) except +
         vector[string] aggregations
         vector[string] decays
-        void initializeCategory(double, int, string, vector[long])
+        void initializeCategory(double, int, string, vector[int64_t])
         pair[vector[vector[double]], vector[vector[int]]] findAllNearestPOIs(
             float, int, string, int)
-        void initializeAccVar(string, vector[long], vector[double])
+        void initializeAccVar(string, vector[int64_t], vector[double])
         vector[double] getAllAggregateAccessibilityVariables(
             float, string, string, string, int)
         vector[int] Route(int, int, int)
-        vector[vector[int]] Routes(vector[long], vector[long], int)
+        vector[vector[int]] Routes(vector[int64_t], vector[int64_t], int)
         double Distance(int, int, int)
-        vector[double] Distances(vector[long], vector[long], int)
-        vector[vector[pair[long, float]]] Range(vector[long], float, int, vector[long])
+        vector[double] Distances(vector[int64_t], vector[int64_t], int)
+        vector[vector[pair[int64_t, float]]] Range(vector[int64_t], float, int, vector[int64_t])
         void precomputeRangeQueries(double)
 
 
-cdef np.ndarray[double] convert_vector_to_array_dbl(vector[double] vec):
-    cdef np.ndarray arr = np.zeros(len(vec), dtype="double")
+cdef np.ndarray[np.float64_t, ndim=1] convert_vector_to_array_dbl(vector[double] vec):
+    cdef Py_ssize_t i
+    cdef np.ndarray[np.float64_t, ndim=1] arr = np.empty(vec.size(), dtype=np.float64)
     for i in range(len(vec)):
         arr[i] = vec[i]
     return arr
 
 
-cdef np.ndarray[double, ndim = 2] convert_2D_vector_to_array_dbl(
+cdef np.ndarray[np.float64_t, ndim=2] convert_2D_vector_to_array_dbl(
         vector[vector[double]] vec):
-    cdef np.ndarray arr = np.empty_like(vec, dtype="double")
-    for i in range(arr.shape[0]):
-        for j in range(arr.shape[1]):
-            arr[i][j] = vec[i][j]
+    cdef Py_ssize_t i
+    cdef Py_ssize_t j
+    cdef Py_ssize_t rows = vec.size()
+    cdef Py_ssize_t cols = vec[0].size() if rows else 0
+    cdef np.ndarray[np.float64_t, ndim=2] arr = np.empty((rows, cols), dtype=np.float64)
+    for i in range(rows):
+        for j in range(cols):
+            arr[i, j] = vec[i][j]
     return arr
 
 
-cdef np.ndarray[int, ndim = 2] convert_2D_vector_to_array_int(
+cdef np.ndarray[np.int32_t, ndim=2] convert_2D_vector_to_array_int(
         vector[vector[int]] vec):
-    cdef np.ndarray arr = np.empty_like(vec, dtype="int")
-    for i in range(arr.shape[0]):
-        for j in range(arr.shape[1]):
-            arr[i][j] = vec[i][j]
+    cdef Py_ssize_t i
+    cdef Py_ssize_t j
+    cdef Py_ssize_t rows = vec.size()
+    cdef Py_ssize_t cols = vec[0].size() if rows else 0
+    cdef np.ndarray[np.int32_t, ndim=2] arr = np.empty((rows, cols), dtype=np.int32)
+    for i in range(rows):
+        for j in range(cols):
+            arr[i, j] = vec[i][j]
     return arr
 
 
@@ -63,10 +75,10 @@ cdef class cyaccess:
 
     def __cinit__(
         self,
-        np.ndarray[long] node_ids,
-        np.ndarray[double, ndim=2] node_xys,
-        np.ndarray[long, ndim=2] edges,
-        np.ndarray[double, ndim=2] edge_weights,
+        np.ndarray[np.int64_t, ndim=1] node_ids,
+        np.ndarray[np.float64_t, ndim=2] node_xys,
+        np.ndarray[np.int64_t, ndim=2] edges,
+        np.ndarray[np.float64_t, ndim=2] edge_weights,
         bool twoway=True
     ):
         """
@@ -90,7 +102,7 @@ cdef class cyaccess:
         double maxdist,
         int maxitems,
         string category,
-        np.ndarray[long] node_ids
+        np.ndarray[np.int64_t, ndim=1] node_ids
     ):
         """
         maxdist - the maximum distance that will later be used in
@@ -125,8 +137,8 @@ cdef class cyaccess:
     def initialize_access_var(
         self,
         string category,
-        np.ndarray[long] node_ids,
-        np.ndarray[double] values
+        np.ndarray[np.int64_t, ndim=1] node_ids,
+        np.ndarray[np.float64_t, ndim=1] values
     ):
         """
         category - category name
@@ -169,8 +181,8 @@ cdef class cyaccess:
         """
         return self.access.Route(srcnode, destnode, impno)
 
-    def shortest_paths(self, np.ndarray[long] srcnodes, 
-            np.ndarray[long] destnodes, int impno=0):
+    def shortest_paths(self, np.ndarray[np.int64_t, ndim=1] srcnodes,
+            np.ndarray[np.int64_t, ndim=1] destnodes, int impno=0):
         """
         srcnodes - node ids of origins
         destnodes - node ids of destinations
@@ -186,8 +198,8 @@ cdef class cyaccess:
         """
         return self.access.Distance(srcnode, destnode, impno)
 
-    def shortest_path_distances(self, np.ndarray[long] srcnodes, 
-            np.ndarray[long] destnodes, int impno=0):
+    def shortest_path_distances(self, np.ndarray[np.int64_t, ndim=1] srcnodes,
+            np.ndarray[np.int64_t, ndim=1] destnodes, int impno=0):
         """
         srcnodes - node ids of origins
         destnodes - node ids of destinations
@@ -198,8 +210,8 @@ cdef class cyaccess:
     def precompute_range(self, double radius):
         self.access.precomputeRangeQueries(radius)
 
-    def nodes_in_range(self, vector[long] srcnodes, float radius, int impno, 
-            np.ndarray[long] ext_ids):
+    def nodes_in_range(self, vector[int64_t] srcnodes, float radius, int impno,
+            np.ndarray[np.int64_t, ndim=1] ext_ids):
         """
         srcnodes - node ids of origins
         radius - maximum range in which to search for nearby nodes

--- a/src/graphalg.cpp
+++ b/src/graphalg.cpp
@@ -4,7 +4,7 @@
 namespace MTC {
 namespace accessibility {
 Graphalg::Graphalg(
-        int numnodes, vector< vector<long> > edges, vector<double> edgeweights,
+        int numnodes, vector< vector<PandanaNodeID> > edges, vector<double> edgeweights,
         bool twoway) {
     this->numnodes = numnodes;
 

--- a/src/graphalg.h
+++ b/src/graphalg.h
@@ -22,7 +22,7 @@ class Graphalg {
  public:
     Graphalg(
         int numnodes,
-        vector< vector<long> > edges, vector<double> edgeweights,
+        vector< vector<PandanaNodeID> > edges, vector<double> edgeweights,
         bool twoway);
 
     std::vector<NodeID> Route(int src, int tgt, int threadNum = 0);

--- a/src/shared.h
+++ b/src/shared.h
@@ -6,7 +6,14 @@
     #define DLLImport
     #define DLLExport
 #endif
+#include <stdint.h>
 #ifdef _OPENMP
 #include <omp.h>
+#else
+#define PANDANA_OMP_FALLBACK
+#define omp_get_thread_num() 0
+#define omp_get_max_threads() 1
 #endif
 #define FILE_LOG(logINFO) (std::cout)
+
+typedef int64_t PandanaNodeID;

--- a/tests/test_cyaccess.py
+++ b/tests/test_cyaccess.py
@@ -6,19 +6,19 @@ import pytest
 import os
 from numpy.testing import assert_almost_equal
 from pandana.cyaccess import cyaccess
+from pandana.loaders.pandash5 import _legacy_compatible_hdf_store
+
+
+def sample_path():
+    return os.path.join(os.path.dirname(__file__), 'osm_sample.h5')
 
 
 @pytest.fixture(scope="module")
-def nodes_and_edges(request):
-    store = pd.HDFStore(
-        os.path.join(os.path.dirname(__file__), 'osm_sample.h5'), "r")
-    nodes = store.nodes
-    edges = store.edges[["from", "to"]]
-    edge_weights = store.edges[["weight"]]
-
-    def fin():
-        store.close()
-    request.addfinalizer(fin)
+def nodes_and_edges():
+    with _legacy_compatible_hdf_store(sample_path()) as store:
+        nodes = store.nodes.copy()
+        edges = store.edges[["from", "to"]].copy()
+        edge_weights = store.edges[["weight"]].copy()
 
     return nodes, edges, edge_weights
 
@@ -33,9 +33,9 @@ def net(nodes_and_edges):
     edges["to"] = node_locations.loc[edges["to"]].values
 
     net = cyaccess(
-        nodes.index.values.astype('int_'),
+        nodes.index.values.astype('int64'),
         nodes.values,
-        edges.values.astype('int_'),
+        edges.values.astype('int64'),
         edge_weights.transpose().values,
         True
     )
@@ -59,7 +59,7 @@ def test_agg_analysis(net, nodes_and_edges):
 
     # test missing aggregation type
     ret = net.get_all_aggregate_accessibility_variables(10, b'test', b'this is', b'bogus')
-    assert np.alltrue(np.isnan(ret))
+    assert np.all(np.isnan(ret))
 
 
 def test_poi_analysis(net, nodes_and_edges):
@@ -93,6 +93,42 @@ def test_shortest_path(net):
     assert route[12] == 1314
     assert route.iloc[20] == 345
     assert net.shortest_path_distance(996, 71) == 23
+
+
+def test_fixed_graph_shortest_path_distances(net):
+    node_pairs_and_distances = np.array([
+        (342, 45, 17),
+        (444, 936, 28),
+        (1140, 1, 35),
+        (317, 1316, 33),
+        (1196, 1129, 22),
+        (921, 1065, 35),
+        (184, 1036, 17),
+        (748, 511, 11),
+        (820, 1074, 34),
+        (1247, 866, 6),
+        (938, 346, 28),
+        (596, 164, 7),
+        (1301, 990, 30),
+        (959, 270, 5),
+        (1055, 1488, 19),
+        (142, 1208, 15),
+        (663, 65, 9),
+        (996, 796, 6),
+        (1271, 867, 21),
+        (164, 39, 32),
+        (1203, 905, 18),
+        (1189, 959, 11),
+        (1025, 437, 26),
+    ], dtype=np.int64)
+
+    actual = np.array([
+        net.shortest_path_distance(origin, destination)
+        for origin, destination in node_pairs_and_distances[:, :2]
+    ], dtype=np.int64)
+
+    expected = node_pairs_and_distances[:, 2]
+    assert np.array_equal(actual, expected)
 
 
 '''

--- a/tests/test_osm.py
+++ b/tests/test_osm.py
@@ -89,7 +89,27 @@ def test_build_node_query_tag_list(bbox1):
         'out;').format(*bbox1)
 
 
-def test_node_query(bbox2):
+def test_node_query(monkeypatch, bbox2):
+    def mock_query(query):
+        return {
+            'elements': [
+                {
+                    'id': 1419597327,
+                    'lat': 37.8672,
+                    'lon': -122.2589,
+                    'tags': {'amenity': 'restaurant', 'name': 'Cream'},
+                },
+                {
+                    'id': 2,
+                    'lat': 37.8674,
+                    'lon': -122.2588,
+                    'tags': {'amenity': 'restaurant', 'name': 'Other'},
+                },
+            ]
+        }
+
+    monkeypatch.setattr(osm, 'make_osm_query', mock_query)
+
     tags = '"amenity"="restaurant"'
     cafes = osm.node_query(*bbox2, tags=tags)
 
@@ -99,6 +119,8 @@ def test_node_query(bbox2):
     assert cafes['name'][1419597327] == 'Cream'
 
 
-def test_node_query_raises():
+def test_node_query_raises(monkeypatch):
+    monkeypatch.setattr(osm, 'make_osm_query', lambda query: {'elements': []})
+
     with pytest.raises(RuntimeError):
         osm.node_query(37.8, -122.282, 37.8, -122.252)

--- a/tests/test_pandana.py
+++ b/tests/test_pandana.py
@@ -9,39 +9,37 @@ import pandana.network as pdna
 from numpy.testing import assert_allclose
 from pandas.testing import assert_index_equal
 
+from pandana.loaders.pandash5 import _legacy_compatible_hdf_store
 from pandana.testing import skipifci
 
 
+def sample_path():
+    return os.path.join(os.path.dirname(__file__), "osm_sample.h5")
+
+
+def load_sample():
+    with _legacy_compatible_hdf_store(sample_path()) as store:
+        return store.nodes.copy(), store.edges.copy()
+
+
 @pytest.fixture(scope="module")
-def sample_osm(request):
-    store = pd.HDFStore(os.path.join(os.path.dirname(__file__), "osm_sample.h5"), "r")
-    nodes, edges = store.nodes, store.edges
+def sample_osm():
+    nodes, edges = load_sample()
 
     net = pdna.Network(nodes.x, nodes.y, edges["from"], edges.to, edges[["weight"]])
 
     net.precompute(2000)
-
-    def fin():
-        store.close()
-
-    request.addfinalizer(fin)
 
     return net
 
 
 # initialize a second network
 @pytest.fixture(scope="module")
-def second_sample_osm(request):
-    store = pd.HDFStore(os.path.join(os.path.dirname(__file__), "osm_sample.h5"), "r")
-    nodes, edges = store.nodes, store.edges
+def second_sample_osm():
+    nodes, edges = load_sample()
     net = pdna.Network(nodes.x, nodes.y, edges["from"], edges.to, edges[["weight"]])
 
     net.precompute(2000)
-
-    def fin():
-        store.close()
-
-    request.addfinalizer(fin)
 
     return net
 
@@ -129,10 +127,9 @@ def test_agg_variables_accuracy(sample_osm):
     assert_allclose(s.mean(), r.std(), atol=1e-2)
 
 
-def test_non_integer_nodeids(request):
+def test_non_integer_nodeids():
 
-    store = pd.HDFStore(os.path.join(os.path.dirname(__file__), "osm_sample.h5"), "r")
-    nodes, edges = store.nodes, store.edges
+    nodes, edges = load_sample()
 
     # convert to string!
     nodes.index = nodes.index.astype("str")
@@ -140,11 +137,6 @@ def test_non_integer_nodeids(request):
     edges["to"] = edges["to"].astype("str")
 
     net = pdna.Network(nodes.x, nodes.y, edges["from"], edges.to, edges[["weight"]])
-
-    def fin():
-        store.close()
-
-    request.addfinalizer(fin)
 
     # test accuracy compared to Pandas functions
     ssize = 50

--- a/tests/test_pandash5.py
+++ b/tests/test_pandash5.py
@@ -102,13 +102,12 @@ def test_network_to_pandas_hdf5(
         tmpfile, network, nodes, edges_df, impedance_names, two_way):
     ph5.network_to_pandas_hdf5(network, tmpfile)
 
-    store = pd.HDFStore(tmpfile)
-
-    assert_frame_equal(store['nodes'], nodes)
-    assert_frame_equal(store['edges'], edges_df)
-    assert_series_equal(store['two_way'], pd.Series([two_way]))
-    assert_series_equal(
-        store['impedance_names'], pd.Series(impedance_names))
+    with pd.HDFStore(tmpfile) as store:
+        assert_frame_equal(store['nodes'], nodes)
+        assert_frame_equal(store['edges'], edges_df)
+        assert_series_equal(store['two_way'], pd.Series([two_way]))
+        assert_series_equal(
+            store['impedance_names'], pd.Series(impedance_names))
 
 
 @skipifci
@@ -117,13 +116,12 @@ def test_network_to_pandas_hdf5_removal(
     nodes, edges = ph5.remove_nodes(network, rm_nodes)
     ph5.network_to_pandas_hdf5(network, tmpfile, rm_nodes)
 
-    store = pd.HDFStore(tmpfile)
-
-    assert_frame_equal(store['nodes'], nodes)
-    assert_frame_equal(store['edges'], edges)
-    assert_series_equal(store['two_way'], pd.Series([two_way]))
-    assert_series_equal(
-        store['impedance_names'], pd.Series(impedance_names))
+    with pd.HDFStore(tmpfile) as store:
+        assert_frame_equal(store['nodes'], nodes)
+        assert_frame_equal(store['edges'], edges)
+        assert_series_equal(store['two_way'], pd.Series([two_way]))
+        assert_series_equal(
+            store['impedance_names'], pd.Series(impedance_names))
 
 
 @skipifci


### PR DESCRIPTION
## Summary
- modernize Pandana's build for NumPy 2, Cython 3, and Python 3.10-3.14
- update the Cython/NumPy boundary to use explicit dtypes and initialize the NumPy C API
- update the contraction hierarchy C++ backend for C++17
- add Pandas/PyTables compatibility handling for legacy Pandana HDF files
- add a fixed-graph shortest-path regression test
- refresh GitHub Actions and wheel builds for current Python versions

## Validation
- Windows 11, Python 3.14.6, NumPy 2.4.6, Pandas 3.0.3
- python setup.py build_ext --inplace --force
- python -m pytest -q -> 35 passed
- python examples/simple_example.py
- python -m pip check
- built and smoke-tested pandana-0.7.1-cp314-cp314-win_amd64.whl

## Notes
Exact-graph shortest-path behavior is preserved. In downstream pipeline testing, full-pipeline drift was traced to different OSM extraction output before Pandana receives the graph, likely from pyrosm version changes rather than Pandana shortest-path computation.

This is opened as a draft while the GitHub-hosted matrix runs.